### PR TITLE
fix(mts): correct isControlled check for undefined ref

### DIFF
--- a/src/components/btc-mts-slider/use-mts-controllable.ts
+++ b/src/components/btc-mts-slider/use-mts-controllable.ts
@@ -65,7 +65,7 @@ type UseMTSControllabeProps<T> = ShallowExpand<
 function isUseMTSControlled<T>(
   props: UseMTSControllabeProps<T>,
 ): props is UseMTSControlledProps<T> {
-  return 'mtsWriteValue' in props;
+  return props.mtsWriteValue != null;
 }
 
 function useMTSControllable<T>(


### PR DESCRIPTION
Before: `isUseMTSControlled` used `'mtsWriteValue' in props`, which returns true even when `mtsWriteValue` is `undefined`, causing all cases to be treated as controlled.

After: Use `props.mtsWriteValue != null `to ensure only non-null external refs are considered controlled.