### PR TITLE
feat(demo): add background blocking toggle via env + macro; update README with demo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # mtc-color-picker
+
 Demo repo showing why Main Thread Components (MTC) are needed in Lynx
-
-
 
 ## Rspeedy project
 
@@ -23,4 +22,28 @@ pnpm run dev
 
 Scan the QRCode in the terminal with your LynxExplorer App to see the result.
 
-You can start editing the page by modifying `src/App.tsx`. The page auto-updates as you edit the file.
+## Testing Background Blocking
+
+This demo includes a toggle for simulating background thread blocking, to verify that Main Thread Scripting (MTS) ensures UI responsiveness even under heavy background load.
+
+Run with blocking enabled:
+
+```bash
+pnpm run demo
+```
+
+This command sets the environment variable:
+
+```json
+"scripts": {
+  "demo": "cross-env LYNX_DEMO_BLOCKING_ENABLED=true rspeedy dev",
+  "build": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy build",
+  "dev": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy dev",
+  "preview": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy preview"
+}
+```
+
+- `LYNX_DEMO_BLOCKING_ENABLED=true` which enables background blocking test mode.
+- By default (dev, build, preview) blocking is disabled.
+
+This makes it easy to reproduce blocking scenarios and confirm that the UI is unaffected thanks to MTS.

--- a/lynx.config.ts
+++ b/lynx.config.ts
@@ -5,12 +5,17 @@ import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
 import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
 
+const blockingEnabled = process.env.LYNX_DEMO_BLOCKING_ENABLED === 'true';
+
 export default defineConfig({
   source: {
     entry: {
       BTCMTSColorPicker: './src/demos/BTCMTSColorPicker.tsx',
       BTCMTSSlider: './src/demos/BTCMTSSlider.tsx',
       BTCSlider: './src/demos/BTCSlider.tsx',
+    },
+    define: {
+      __ENABLE_BACKGROUND_BLOCKING__: JSON.stringify(blockingEnabled),
     },
   },
   plugins: [

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "rspeedy build",
-    "dev": "rspeedy dev",
+    "demo": "cross-env LYNX_DEMO_BLOCKING_ENABLED=true rspeedy dev",
+    "build": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy build",
+    "dev": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy dev",
     "format": "prettier --write .",
-    "preview": "rspeedy preview"
+    "preview": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy preview"
   },
   "dependencies": {
     "@lynx-js/react": "^0.112.4"
@@ -19,6 +20,7 @@
     "@lynx-js/types": "3.3.0",
     "@rsbuild/plugin-type-check": "1.2.4",
     "@types/react": "^18.3.23",
+    "cross-env": "^10.0.0",
     "prettier": "^3.6.2",
     "rsbuild-plugin-tailwindcss": "^0.2.3",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@types/react':
         specifier: ^18.3.23
         version: 18.3.23
+      cross-env:
+        specifier: ^10.0.0
+        version: 10.0.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -72,6 +75,9 @@ packages:
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@hongzhiyuan/preact@10.24.0-00213bad':
     resolution: {integrity: sha512-bHWp4ZDK5ZimcY+bTWw3S3xGiB8eROpZj0RK3FClNIaTOajb0b11CsT3K+pdeakgPgq1jWN3T2e2rfrPm40JsQ==}
@@ -861,6 +867,11 @@ packages:
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
+
+  cross-env@10.0.0:
+    resolution: {integrity: sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2352,6 +2363,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@hongzhiyuan/preact@10.24.0-00213bad': {}
 
   '@isaacs/cliui@8.0.2':
@@ -3260,6 +3273,11 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cross-env@10.0.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/demos/BTCMTSColorPicker.tsx
+++ b/src/demos/BTCMTSColorPicker.tsx
@@ -1,7 +1,14 @@
 import { root, runOnBackground, useCallback, useState } from '@lynx-js/react';
 import { AppLayout } from '@/App';
+import { sleep } from '@/utils/sleep';
 
 import { ColorPicker } from '@/components/btc-mts-colorpicker/MTSColorPicker';
+
+if (__BACKGROUND__) {
+  setInterval(() => {
+    sleep(250);
+  }, 100);
+}
 
 export function App() {
   const [value, setValue] = useState<readonly [number, number, number]>([

--- a/src/demos/BTCMTSSlider.tsx
+++ b/src/demos/BTCMTSSlider.tsx
@@ -1,36 +1,44 @@
 import {
   root,
   runOnBackground,
+  //useMainThreadRef,
   useCallback,
-  useMainThreadRef,
   useState,
 } from '@lynx-js/react';
 import { AppLayout } from '@/App';
+import { sleep } from '@/utils/sleep';
 
 import { HueSlider } from '@/components/btc-mts-slider/MTSSlider';
-import type { MTSWriterWithControls } from '@/components/btc-mts-slider/MTSSlider';
+// import type { MTSWriterWithControls } from '@/components/btc-mts-slider/MTSSlider';
+
+if (__BACKGROUND__) {
+  setInterval(() => {
+    sleep(250);
+  }, 100);
+}
 
 export function App() {
-  const [value, setValue] = useState(200);
+  const [value, setValue] = useState(199);
 
-  const mtsWriteValue = useMainThreadRef<MTSWriterWithControls<number>>();
+  // Uncomment `mtsWriteValue` to test BTC owned writer behavior.
+  // const mtsWriteValue = useMainThreadRef<MTSWriterWithControls<number>>();
 
   const onMTSValueChange = useCallback((next: number) => {
     'main thread';
-    mtsWriteValue.current?.(next);
+    //mtsWriteValue.current?.(next);
     runOnBackground(setValue)(next);
   }, []);
 
   return (
-    <AppLayout title="BTC-MTS Slider" h={value} s={100} l={50}>
+    <AppLayout title="BTC-MTS Slider" h={value} s={99} l={72}>
       <view className="w-60 h-12 flex-row justify-center items-center">
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-12">
         <HueSlider
           initialValue={value}
-          mtsWriteValue={mtsWriteValue}
           onMTSChange={onMTSValueChange}
+          // mtsWriteValue={mtsWriteValue}
         />
       </view>
     </AppLayout>

--- a/src/demos/BTCSlider.tsx
+++ b/src/demos/BTCSlider.tsx
@@ -1,27 +1,29 @@
-import { root, useState } from '@lynx-js/react';
+import { root, useCallback, useState } from '@lynx-js/react';
 import { AppLayout } from '@/App';
 
 import { HueSlider } from '@/components/btc-slider/Slider';
+import { sleep } from '@/utils/sleep';
+
+if (__BACKGROUND__) {
+  setInterval(() => {
+    sleep(150);
+  }, 100);
+}
 
 export function App() {
-  const [value, setValue] = useState(120);
+  const [value, setValue] = useState(199);
+
+  const onChange = useCallback((next: number) => {
+    setValue(next);
+  }, []);
 
   return (
-    <AppLayout title="BTC Slider" h={value} s={100} l={50}>
+    <AppLayout title="BTC Slider" h={value} s={99} l={72}>
       <view className="w-60 h-12 flex-row justify-center items-center">
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-12">
-        <HueSlider
-          value={value}
-          onChange={(value) => {
-            setValue(value);
-            console.log('updating');
-          }}
-          onCommit={(value) => {
-            console.log('commit', value);
-          }}
-        />
+        <HueSlider defaultValue={value} onChange={onChange} />
       </view>
     </AppLayout>
   );

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,4 @@
+declare global {
+  const __ENABLE_BACKGROUND_BLOCKING__ = boolean;
+}
+export {};

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,12 @@
+/**
+ * Busy-loop: block current thread for `ms` milliseconds.
+ * - Blocks the event loop, so no other tasks can run.
+ * - Use only in blocking scenarios.
+ * @param ms milliseconds
+ */
+export function sleep(ms: number) {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    // Intentionally do nothing
+  }
+}

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -5,8 +5,10 @@
  * @param ms milliseconds
  */
 export function sleep(ms: number) {
-  const start = Date.now();
-  while (Date.now() - start < ms) {
-    // Intentionally do nothing
+  if (__ENABLE_BACKGROUND_BLOCKING__) {
+    const start = Date.now();
+    while (Date.now() - start < ms) {
+      // Intentionally do nothing
+    }
   }
 }


### PR DESCRIPTION
### Background

This PR introduces a controllable background blocking mechanism to test whether Main Thread Scripting (MTS) can ensure the UI remains responsive even when background threads are blocked.

### Changes

Added `LYNX_DEMO_BLOCKING_ENABLED` environment variable (via `cross-env`) to control blocking mode at startup.

Introduced `__ENABLE_BACKGROUND_BLOCKING__` compile-time macro to enable/disable blocking logic during build.

Implemented background thread blocking in the demo app to simulate heavy load (sleep loop).

Updated README to document how to enable the blocking test with pnpm run demo.

### Purpose

By enabling blocking on background threads, we can validate that MTS successfully isolates UI rendering from background workload. This helps ensure the architecture's robustness under blocking conditions.

### Notes

Default behavior keeps blocking disabled (`LYNX_DEMO_BLOCKING_ENABLED=false`).

Run `pnpm run demo` to enable blocking mode for testing.