### PR TITLE
feat(demo): add 2nd BTC-MTS ColorPicker demo (coordinate on BTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Scan the QRCode in the terminal with your LynxExplorer App to see the result.
 
 ## Testing Background Blocking
 
-This demo includes a toggle for simulating background thread blocking, to verify that Main Thread Scripting (MTS) ensures UI responsiveness even under heavy background load.
+This demo includes a toggle for simulating background thread blocking, to verify that Main-Thread Scripting (MTS) ensures UI responsiveness even under heavy background load.
 
 Run with blocking enabled:
 

--- a/lynx.config.ts
+++ b/lynx.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
   source: {
     entry: {
       MTCColorPicker: './src/demos/MTCColorPicker.tsx',
-      BTCMTSColorPicker: './src/demos/BTCMTSColorPicker.tsx',
+      'BTCMTSColorPicker-MTSCoord': './src/demos/BTCMTSColorPicker.tsx',
+      'BTCMTSColorPicker-BTCCoord': './src/demos/BTCBTCMTSColorPicker.tsx',
       BTCMTSSlider: './src/demos/BTCMTSSlider.tsx',
       BTCSlider: './src/demos/BTCSlider.tsx',
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import './App.css';
 
 export interface AppLayoutProps {
   title?: string;
+  subtitle?: string;
   children?: ReactNode;
   /** Hue (0–360) */
   h?: number;
@@ -17,6 +18,7 @@ export interface AppLayoutProps {
 }
 export function AppLayout({
   title = 'Demo',
+  subtitle,
   children,
   h,
   s,
@@ -29,16 +31,23 @@ export function AppLayout({
   }, [h, s, l]);
 
   return (
-    <page className="dark p-16 flex-col justify-center items-center bg-base-1">
-      <text className="text-content text-3xl mb-12">{title}</text>
+    <page className={`dark flex-col items-center bg-base-1`}>
+      <view
+        className={`absolute w-full h-20 flex-col justify-end items-center ${subtitle ? 'bottom-[calc(33.33%+336px)]' : 'bottom-[calc(33.33%+372px)]'}`}
+      >
+        <text className="text-content text-3xl">{title}</text>
+        {subtitle && (
+          <text className="text-content text-2xl opacity-60">{subtitle}</text>
+        )}
+      </view>
       {/* ColorDisplay */}
       <MaskIcon
         iconUrl={logoUrl}
-        className="rounded-full size-72 bg-content"
+        className="absolute bottom-1/3 rounded-full size-72 bg-content"
         style={color ? { backgroundColor: color } : undefined}
       />
       {/* BottomSheet */}
-      <view className="absolute bottom-0 w-full h-1/3 p-4 flex-col items-center bg-base-4 rounded-t-lg shadow-xl">
+      <view className="absolute bottom-0 w-full h-[calc(33.33%+24px)] p-4 flex-col items-center bg-base-4 rounded-t-lg shadow-xl">
         {children}
       </view>
     </page>

--- a/src/components/btc-mts/BTCMTSColorPicker.tsx
+++ b/src/components/btc-mts/BTCMTSColorPicker.tsx
@@ -1,0 +1,84 @@
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  runOnBackground,
+} from '@lynx-js/react';
+import { HueSlider, LightnessSlider, SaturationSlider } from './BTCMTSSlider';
+import { HSLGradients } from '@/utils/hsl-gradients';
+
+type Color = readonly [number, number, number];
+
+interface ColorPickerProps {
+  initialHSL?: Color;
+  onHSLChange?: (next: Color) => void;
+}
+
+function ColorPicker({
+  initialHSL = [199, 99, 72],
+  onHSLChange,
+}: ColorPickerProps) {
+  const [hue, setHue] = useState(initialHSL[0]);
+  const [saturation, setSaturation] = useState(initialHSL[1]);
+  const [lightness, setLightness] = useState(initialHSL[2]);
+
+  const { edge: hueEdge, track: hueTrack } = useMemo(
+    () => HSLGradients.hueGradientPair(saturation, lightness),
+    [saturation, lightness],
+  );
+
+  const { edge: satEdge, track: satTrack } = useMemo(
+    () => HSLGradients.saturationGradientPair(hue, lightness),
+    [hue, lightness],
+  );
+
+  const { edge: lightEdge, track: lightTrack } = useMemo(
+    () => HSLGradients.lightnessGradientPair(hue, saturation),
+    [hue, saturation],
+  );
+
+  const handleHueChange = useCallback((v: number) => {
+    'main thread';
+    runOnBackground(setHue)(v);
+  }, []);
+
+  const handleSaturtaionChange = useCallback((v: number) => {
+    'main thread';
+    runOnBackground(setSaturation)(v);
+  }, []);
+
+  const handleLightnessChange = useCallback((v: number) => {
+    'main thread';
+    runOnBackground(setLightness)(v);
+  }, []);
+
+  useEffect(() => {
+    onHSLChange?.([hue, saturation, lightness]);
+  }, [hue, saturation, lightness]);
+
+  return (
+    <view className="w-full h-full flex flex-col gap-y-4">
+      <HueSlider
+        initialValue={hue}
+        onMTSChange={handleHueChange}
+        rootStyle={{ backgroundImage: hueEdge }}
+        trackStyle={{ backgroundImage: hueTrack }}
+      />
+      <SaturationSlider
+        initialValue={saturation}
+        onMTSChange={handleSaturtaionChange}
+        rootStyle={{ backgroundImage: satEdge }}
+        trackStyle={{ backgroundImage: satTrack }}
+      />
+      <LightnessSlider
+        initialValue={lightness}
+        onMTSChange={handleLightnessChange}
+        rootStyle={{ backgroundImage: lightEdge }}
+        trackStyle={{ backgroundImage: lightTrack }}
+      />
+    </view>
+  );
+}
+
+export { ColorPicker };

--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useMainThreadRef } from '@lynx-js/react';
+import type { MainThread, CSSProperties } from '@lynx-js/types';
+import { useMTSSlider } from './use-mts-slider';
+import type { MTSWriterWithControlsRef } from './use-mts-slider';
+import type { Expand } from '@/types/utils';
+
+interface BTCMTSSliderProps {
+  mtsWriteValue?: MTSWriterWithControlsRef<number>;
+  initialValue?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  onMTSChange?: (value: number) => void;
+  onMTSCommit?: (value: number) => void;
+  onMTSInit?: (ref: MainThread.Element) => void;
+
+  // Styling
+  rootStyle?: CSSProperties;
+  trackStyle?: CSSProperties;
+}
+
+/** ================= Base Slider ================= */
+
+function BTCMTSSlider(props: BTCMTSSliderProps) {
+  const {
+    mtsWriteValue,
+    initialValue,
+    onMTSInit,
+    onMTSChange,
+    onMTSCommit,
+    min,
+    rootStyle,
+    trackStyle,
+    ...restProps
+  } = props;
+
+  const mtsThumbRef = useMainThreadRef<MainThread.Element | null>(null);
+
+  const mtsUpdateListenerRef = useMainThreadRef<(value: number) => void>();
+
+  const onMTSDerivedChange = useCallback((value: number) => {
+    'main thread';
+    if (mtsUpdateListenerRef.current) {
+      mtsUpdateListenerRef.current(value);
+    }
+  }, []);
+
+  const {
+    ratioRef,
+    writeValue,
+    onMTSPointerDown,
+    onMTSPointerMove,
+    onMTSPointerUp,
+    onMTSTrackLayoutChange,
+  } = useMTSSlider({
+    initialValue,
+    mtsWriteValue,
+    onMTSDerivedChange,
+    onMTSChange,
+    onMTSCommit,
+    ...restProps,
+  });
+
+  const updateThumbStyle = () => {
+    'main thread';
+    if (mtsThumbRef.current) {
+      mtsThumbRef.current.setStyleProperties({
+        left: `${ratioRef.current * 100}%`,
+      });
+    }
+  };
+
+  const initRoot = useCallback((ref: MainThread.Element) => {
+    'main thread';
+    // Bind writeValue to mtsWriteValue
+    if (ref) {
+      writeValue.init();
+    } else {
+      writeValue.dispose();
+    }
+    // Initialization callback
+    onMTSInit?.(ref);
+  }, []);
+
+  const initThumb = useCallback((ref: MainThread.Element) => {
+    'main thread';
+    mtsThumbRef.current = ref;
+    if (ref) {
+      mtsUpdateListenerRef.current = updateThumbStyle;
+    } else {
+      mtsUpdateListenerRef.current = undefined;
+    }
+    updateThumbStyle();
+  }, []);
+
+  return (
+    // Root
+    <view
+      main-thread:ref={initRoot}
+      main-thread:bindtouchstart={onMTSPointerDown}
+      main-thread:bindtouchmove={onMTSPointerMove}
+      main-thread:bindtouchend={onMTSPointerUp}
+      main-thread:bindtouchcancel={onMTSPointerUp}
+      className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
+      style={rootStyle}
+    >
+      {/* Track Positioner */}
+      <view
+        main-thread:bindlayoutchange={onMTSTrackLayoutChange}
+        className="relative w-full h-full flex flex-row items-center"
+      >
+        {/* Track Visualizer */}
+        <view className="w-full h-full bg-secondary" style={trackStyle}></view>
+        <view
+          main-thread:ref={initThumb}
+          className="absolute bg-white size-8 rounded-full -translate-x-1/2 shadow-md"
+        ></view>
+      </view>
+    </view>
+  );
+}
+
+type HSLSliderProps = Expand<Omit<BTCMTSSliderProps, 'min' | 'max' | 'step'>>;
+
+/** ================= Hue Slider ================= */
+
+function HueSlider(props: HSLSliderProps) {
+  return <BTCMTSSlider min={0} max={360} step={1} {...props} />;
+}
+
+/** ================= Saturation Slider ================= */
+
+function SaturationSlider(props: HSLSliderProps) {
+  return <BTCMTSSlider min={0} max={100} step={1} {...props} />;
+}
+
+/** ================= Lightness Slider ================= */
+
+function LightnessSlider(props: HSLSliderProps) {
+  return <BTCMTSSlider min={0} max={100} step={1} {...props} />;
+}
+
+export { HueSlider, SaturationSlider, LightnessSlider };

--- a/src/components/btc-mts/MTSColorPicker.tsx
+++ b/src/components/btc-mts/MTSColorPicker.tsx
@@ -1,27 +1,26 @@
 import { useCallback, useMainThreadRef } from '@lynx-js/react';
-import {
-  HueSlider,
-  LightnessSlider,
-  SaturationSlider,
-} from '@/components/btc-mts/MTSSlider';
-import type { MTSWriter } from '@/components/btc-mts/MTSSlider';
+import { HueSlider, LightnessSlider, SaturationSlider } from './MTSSlider';
+import type { MTSWriter } from './MTSSlider';
+
+type Color = readonly [number, number, number];
+type Vector2 = readonly [number, number];
 
 interface ColorPickerProps {
-  initialHSL?: readonly [number, number, number];
-  onMTSHSLChange?: (next: readonly [h: number, s: number, l: number]) => void;
+  initialHSL?: Color;
+  onMTSHSLChange?: (next: Color) => void;
 }
 function ColorPicker({
   initialHSL = [199, 99, 72],
   onMTSHSLChange,
 }: ColorPickerProps) {
   const mtsHueRef = useMainThreadRef<number>(initialHSL[0]);
-  const mtsWriteSL = useMainThreadRef<MTSWriter<readonly [number, number]>>();
+  const mtsWriteSL = useMainThreadRef<MTSWriter<Vector2>>();
 
   const mtsSaturationRef = useMainThreadRef<number>(initialHSL[1]);
-  const mtsWriteHL = useMainThreadRef<MTSWriter<readonly [number, number]>>();
+  const mtsWriteHL = useMainThreadRef<MTSWriter<Vector2>>();
 
   const mtsLightnessRef = useMainThreadRef<number>(initialHSL[2]);
-  const mtsWriteHS = useMainThreadRef<MTSWriter<readonly [number, number]>>();
+  const mtsWriteHS = useMainThreadRef<MTSWriter<Vector2>>();
 
   const writeSliderGradients = useCallback(() => {
     'main thread';

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -11,6 +11,7 @@ import type { RefWriteAction } from './use-mts-controllable';
 import { resolveNextValue } from './use-mts-controllable';
 import { HSLGradients } from '@/utils/hsl-gradients';
 import { MTSHSLGradients } from '@/utils/mts-hsl-gradients';
+import type { Expand } from '@/types/utils';
 
 interface MTSSliderProps {
   mtsWriteValue?: MTSWriterWithControlsRef<number>;
@@ -192,7 +193,7 @@ function HueSlider({
   initialSL = [100, 50],
   mtsWriteSL,
   disabled,
-}: Omit<MTSSliderProps, 'min' | 'max' | 'step'> & {
+}: Expand<Omit<MTSSliderProps, 'min' | 'max' | 'step'>> & {
   initialSL?: readonly [number, number];
   mtsWriteSL?: MTSWriterRef<readonly [number, number]>;
 }) {
@@ -255,7 +256,7 @@ function SaturationSlider({
   initialHL = [0, 50],
   mtsWriteHL,
   disabled,
-}: Omit<MTSSliderProps, 'min' | 'max' | 'step'> & {
+}: Expand<Omit<MTSSliderProps, 'min' | 'max' | 'step'>> & {
   initialHL?: readonly [number, number];
   mtsWriteHL?: MTSWriterRef<readonly [number, number]>;
 }) {
@@ -317,7 +318,7 @@ function LightnessSlider({
   initialHS = [0, 100],
   mtsWriteHS,
   disabled,
-}: Omit<MTSSliderProps, 'min' | 'max' | 'step'> & {
+}: Expand<Omit<MTSSliderProps, 'min' | 'max' | 'step'>> & {
   initialHS?: readonly [number, number];
   mtsWriteHS?: MTSWriterRef<readonly [number, number]>;
 }) {

--- a/src/components/btc-mts/use-mts-pointer-interaction.ts
+++ b/src/components/btc-mts/use-mts-pointer-interaction.ts
@@ -1,7 +1,6 @@
 import { useMainThreadRef, useCallback } from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
-// import { useMTSEffectEvent } from './use-mts-effect-event';
 /**
  * Raw pointer position relative to an element's bounding box.
  */
@@ -54,17 +53,10 @@ function useMTSPointerInteraction({
   const elementLeftRef = useMainThreadRef<number | null>(null);
   const elementWidthRef = useMainThreadRef(0);
 
-  /** (Optional) Container metrics kept for future policies (hit-testing, scroll compensation, etc.) */
-  const containerLeftRef = useMainThreadRef<number | null>(null);
-  const containerWidthRef = useMainThreadRef(0);
-
   /** Last computed pointer position snapshot */
   const posRef = useMainThreadRef<PointerPosition | null>(null);
 
   const draggingRef = useMainThreadRef(false);
-
-  // const stableUpdate = useMTSEffectEvent(onMTSUpdate);
-  // const stableCommit = useMTSEffectEvent(onMTSCommit);
 
   const buildPosition = useCallback((x: number): PointerPosition | null => {
     'main thread';
@@ -88,7 +80,6 @@ function useMTSPointerInteraction({
       buildPosition(e.detail.x);
       if (posRef.current) {
         onMTSUpdate?.(posRef.current);
-        //stableUpdate(posRef.current);
       }
     },
     [buildPosition, onMTSUpdate],
@@ -101,7 +92,6 @@ function useMTSPointerInteraction({
       buildPosition(e.detail.x);
       if (posRef.current) {
         onMTSUpdate?.(posRef.current);
-        // stableUpdate(posRef.current);
       }
     },
     [buildPosition, onMTSUpdate],
@@ -114,8 +104,6 @@ function useMTSPointerInteraction({
       buildPosition(e.detail.x);
       if (posRef.current) {
         onMTSCommit?.(posRef.current);
-        // stableUpdate(posRef.current);
-        // stableCommit(posRef.current);
       }
     },
     [buildPosition, onMTSCommit],
@@ -132,23 +120,11 @@ function useMTSPointerInteraction({
     [],
   );
 
-  const onContainerLayoutChange = useCallback(
-    async (e: MainThread.LayoutChangeEvent) => {
-      'main thread';
-      containerWidthRef.current = e.detail.width;
-      const rect: { left: number } =
-        await e.currentTarget.invoke('boundingClientRect');
-      containerLeftRef.current = rect.left;
-    },
-    [],
-  );
-
   return {
     onMTSPointerDown: onPointerDown,
     onMTSPointerMove: onPointerMove,
     onMTSPointerUp: onPointerUp,
     onMTSElementLayoutChange: onElementLayoutChange,
-    onMTSContainerLayoutChange: onContainerLayoutChange,
   };
 }
 
@@ -157,9 +133,6 @@ interface UseMTSPointerInteractionReturnValue {
   onMTSPointerMove: (e: MainThread.TouchEvent) => void;
   onMTSPointerUp: (e: MainThread.TouchEvent) => void;
   onMTSElementLayoutChange: (e: MainThread.LayoutChangeEvent) => Promise<void>;
-  onMTSContainerLayoutChange: (
-    e: MainThread.LayoutChangeEvent,
-  ) => Promise<void>;
 }
 
 export { useMTSPointerInteraction };

--- a/src/components/btc/use-controllable.ts
+++ b/src/components/btc/use-controllable.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from '@lynx-js/react';
 import type { Dispatch, SetStateAction } from '@lynx-js/react';
 
 import { useEffectEvent, noop } from './use-effect-event';
+import type { Expand } from '@/types/utils';
 
 function isUpdater<T>(v: SetStateAction<T>): v is (prev: T) => T {
   return typeof v === 'function';
@@ -49,7 +50,7 @@ function useControllable<T>({
 function useUncontrolled<T>({
   defaultValue,
   onChange,
-}: Omit<UseControllabeProps<T>, 'value'>) {
+}: Expand<Omit<UseControllabeProps<T>, 'value'>>) {
   const [current, setCurrent] = useState<T | undefined>(defaultValue);
   const prevRef = useRef(current);
   const stableOnChange = useEffectEvent(onChange ?? noop);

--- a/src/components/mtc/MTCSlider.tsx
+++ b/src/components/mtc/MTCSlider.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties } from '@lynx-js/types';
 import { useMTCSlider } from './use-mtc-slider';
 import type { UseMTCSliderProps } from './use-mtc-slider';
 import { HSLGradients } from '@/utils/hsl-gradients';
+import type { Expand } from '@/types/utils';
 
 interface MTCSliderProps extends UseMTCSliderProps {
   // Styling
@@ -69,7 +70,7 @@ function MTCHueSlider({
   onChange,
   onCommit,
   disabled,
-}: Omit<MTCSliderProps, 'min' | 'max' | 'step'> & {
+}: Expand<Omit<MTCSliderProps, 'min' | 'max' | 'step'>> & {
   s?: ReturnType<typeof useSignal<number>>;
   l?: ReturnType<typeof useSignal<number>>;
 }) {
@@ -104,7 +105,7 @@ function MTCSaturationSlider({
   onChange,
   onCommit,
   disabled,
-}: Omit<MTCSliderProps, 'min' | 'max' | 'step'> & {
+}: Expand<Omit<MTCSliderProps, 'min' | 'max' | 'step'>> & {
   h?: ReturnType<typeof useSignal<number>>;
   l?: ReturnType<typeof useSignal<number>>;
 }) {
@@ -139,7 +140,7 @@ function MTCLightnessSlider({
   onChange,
   onCommit,
   disabled,
-}: Omit<MTCSliderProps, 'min' | 'max' | 'step'> & {
+}: Expand<Omit<MTCSliderProps, 'min' | 'max' | 'step'>> & {
   h?: ReturnType<typeof useSignal<number>>;
   s?: ReturnType<typeof useSignal<number>>;
 }) {

--- a/src/demos/BTCBTCMTSColorPicker.tsx
+++ b/src/demos/BTCBTCMTSColorPicker.tsx
@@ -1,8 +1,8 @@
 import { root, useState } from '@lynx-js/react';
 import { AppLayout } from '@/App';
-import { MTCColorPicker } from '@/components/mtc/MTCColorPicker';
-import { DummyStyle } from '@/components/shared/DummyStyle';
 import { sleep } from '@/utils/sleep';
+
+import { ColorPicker } from '@/components/btc-mts/BTCMTSColorPicker';
 
 if (__BACKGROUND__) {
   setInterval(() => {
@@ -10,33 +10,24 @@ if (__BACKGROUND__) {
   }, 100);
 }
 
-type Color = readonly [number, number, number];
-
 export function App() {
-  const [value, setValue] = useState<Color>(() => [199, 99, 72]);
-
-  function onMTCValueChange(v: Color) {
-    'use background';
-    setValue(v);
-  }
+  const [value, setValue] = useState<readonly [number, number, number]>([
+    199, 99, 72,
+  ]);
 
   return (
     <AppLayout
-      title="MTC ColorPicker"
-      subtitle="Coordinate on MTS"
+      title="BTC-MTS ColorPicker"
+      subtitle="Coordinate on BTS"
       h={value[0]}
       s={value[1]}
       l={value[2]}
     >
-      <DummyStyle />
       <view className="w-60 h-12 flex-row justify-center items-center">
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-48">
-        <MTCColorPicker
-          initialValue={value}
-          onMTCValueChange={onMTCValueChange}
-        />
+        <ColorPicker initialHSL={value} onHSLChange={setValue} />
       </view>
     </AppLayout>
   );

--- a/src/demos/BTCMTSColorPicker.tsx
+++ b/src/demos/BTCMTSColorPicker.tsx
@@ -26,6 +26,7 @@ export function App() {
   return (
     <AppLayout
       title="BTC-MTS ColorPicker"
+      subtitle="Coordinate on MTS"
       h={value[0]}
       s={value[1]}
       l={value[2]}

--- a/src/demos/BTCMTSSlider.tsx
+++ b/src/demos/BTCMTSSlider.tsx
@@ -39,6 +39,7 @@ export function App() {
           initialValue={value}
           onMTSChange={onMTSValueChange}
           // mtsWriteValue={mtsWriteValue}
+          initialSL={[99, 72]}
         />
       </view>
     </AppLayout>

--- a/src/demos/BTCSlider.tsx
+++ b/src/demos/BTCSlider.tsx
@@ -23,7 +23,7 @@ export function App() {
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-12">
-        <HueSlider defaultValue={value} onChange={onChange} />
+        <HueSlider defaultValue={value} onChange={onChange} s={99} l={72} />
       </view>
     </AppLayout>
   );

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,3 @@
+export type Expand<T> = {
+  [K in keyof T]: T[K];
+} & {};


### PR DESCRIPTION
This PR introduces a second demo for BTC-MTS ColorPicker, where the coordination logic of sliders is executed on the background thread (as opposed to the previous version running on main thread).

Additional changes:
Refined app layout structure for better visual balance.