### PR TITLE
refactor(pointer): align API and clean up types for BTC/MTS/MTC pointer interactions

### DIFF
--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -49,10 +49,10 @@ function BTCMTSSlider(props: BTCMTSSliderProps) {
   const {
     ratioRef,
     writeValue,
-    onMTSPointerDown,
-    onMTSPointerMove,
-    onMTSPointerUp,
-    onMTSTrackLayoutChange,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleElementLayoutChange,
   } = useMTSSlider({
     initialValue,
     mtsWriteValue,
@@ -98,16 +98,16 @@ function BTCMTSSlider(props: BTCMTSSliderProps) {
     // Root
     <view
       main-thread:ref={initRoot}
-      main-thread:bindtouchstart={onMTSPointerDown}
-      main-thread:bindtouchmove={onMTSPointerMove}
-      main-thread:bindtouchend={onMTSPointerUp}
-      main-thread:bindtouchcancel={onMTSPointerUp}
+      main-thread:bindtouchstart={handlePointerDown}
+      main-thread:bindtouchmove={handlePointerMove}
+      main-thread:bindtouchend={handlePointerUp}
+      main-thread:bindtouchcancel={handlePointerUp}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
       style={rootStyle}
     >
       {/* Track Positioner */}
       <view
-        main-thread:bindlayoutchange={onMTSTrackLayoutChange}
+        main-thread:bindlayoutchange={handleElementLayoutChange}
         className="relative w-full h-full flex flex-row items-center"
       >
         {/* Track Visualizer */}

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -70,10 +70,10 @@ function MTSSlider(props: MTSSliderProps) {
   const {
     ratioRef,
     writeValue,
-    onMTSPointerDown,
-    onMTSPointerMove,
-    onMTSPointerUp,
-    onMTSTrackLayoutChange,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleElementLayoutChange,
   } = useMTSSlider({
     initialValue,
     mtsWriteValue,
@@ -158,15 +158,15 @@ function MTSSlider(props: MTSSliderProps) {
     // Root
     <view
       main-thread:ref={initRoot}
-      main-thread:bindtouchstart={onMTSPointerDown}
-      main-thread:bindtouchmove={onMTSPointerMove}
-      main-thread:bindtouchend={onMTSPointerUp}
-      main-thread:bindtouchcancel={onMTSPointerUp}
+      main-thread:bindtouchstart={handlePointerDown}
+      main-thread:bindtouchmove={handlePointerMove}
+      main-thread:bindtouchend={handlePointerUp}
+      main-thread:bindtouchcancel={handlePointerUp}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
     >
       {/* Track Positioner */}
       <view
-        main-thread:bindlayoutchange={onMTSTrackLayoutChange}
+        main-thread:bindlayoutchange={handleElementLayoutChange}
         className="relative w-full h-full flex flex-row items-center"
       >
         {/* Track Visualizer */}

--- a/src/components/btc-mts/use-mts-pointer-interaction.ts
+++ b/src/components/btc-mts/use-mts-pointer-interaction.ts
@@ -1,38 +1,11 @@
-import { useMainThreadRef, useCallback } from '@lynx-js/react';
+import { useMainThreadRef } from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
-/**
- * Raw pointer position relative to an element's bounding box.
- */
-interface PointerPosition {
-  /**
-   * Horizontal offset from the element's left edge, in pixels.
-   * May be < 0 if the pointer is left of the element,
-   * or > elementWidth if the pointer is right of the element.
-   */
-  offset: number;
-
-  /**
-   * Normalized ratio of offset / elementWidth.
-   * May be < 0 or > 1 if pointer is outside.
-   */
-  offsetRatio: number;
-
-  /** Width of the element's bounding box in pixels. */
-  elementWidth: number;
-}
-
-/**
- * Pointer to element-local coordinates adapter.
- * - Converts global pointer X into element-relative offset and ratio.
- * - Does not apply clamp, min/max, or step logic (leave that to higher-level hooks).
- */
-interface UseMTSPointerInteractionProps {
-  /** Called continuously while pointer moves (dragging). */
-  onMTSUpdate?: (pos: PointerPosition) => void;
-  /** Called once at the end of an interaction (pointer up). */
-  onMTSCommit?: (pos: PointerPosition) => void;
-}
+import type {
+  PointerPosition,
+  UsePointerInteractionProps,
+  UsePointerInteractionReturnValueBase,
+} from '@/types/pointer';
 
 /**
  * Pointer interactions with split responsibilities:
@@ -41,14 +14,14 @@ interface UseMTSPointerInteractionProps {
  *   against the element's measured bounding rect.
  *
  * Notes:
- * - We rely on `onElementLayoutChange` to keep `left/width` fresh.
+ * - We rely on `handleElementLayoutChange` to keep `left/width` fresh.
  * - If element metrics are not ready when a pointer event arrives, we skip updates safely.
  */
 
-function useMTSPointerInteraction({
-  onMTSUpdate,
-  onMTSCommit,
-}: UseMTSPointerInteractionProps = {}) {
+function usePointerInteraction({
+  onUpdate,
+  onCommit,
+}: UsePointerInteractionProps = {}) {
   /** Element (coordinate frame) metrics */
   const elementLeftRef = useMainThreadRef<number | null>(null);
   const elementWidthRef = useMainThreadRef(0);
@@ -58,7 +31,7 @@ function useMTSPointerInteraction({
 
   const draggingRef = useMainThreadRef(false);
 
-  const buildPosition = useCallback((x: number): PointerPosition | null => {
+  const buildPosition = (x: number): PointerPosition | null => {
     'main thread';
     const elementWidth = elementWidthRef.current;
     const elementLeft = elementLeftRef.current;
@@ -71,73 +44,55 @@ function useMTSPointerInteraction({
       return pos;
     }
     return null;
-  }, []);
+  };
 
-  const onPointerDown = useCallback(
-    (e: MainThread.TouchEvent) => {
-      'main thread';
-      draggingRef.current = true;
-      buildPosition(e.detail.x);
-      if (posRef.current) {
-        onMTSUpdate?.(posRef.current);
-      }
-    },
-    [buildPosition, onMTSUpdate],
-  );
+  const handlePointerDown = (e: MainThread.TouchEvent) => {
+    'main thread';
+    draggingRef.current = true;
+    buildPosition(e.detail.x);
+    if (posRef.current) {
+      onUpdate?.(posRef.current);
+    }
+  };
 
-  const onPointerMove = useCallback(
-    (e: MainThread.TouchEvent) => {
-      'main thread';
-      if (!draggingRef.current) return;
-      buildPosition(e.detail.x);
-      if (posRef.current) {
-        onMTSUpdate?.(posRef.current);
-      }
-    },
-    [buildPosition, onMTSUpdate],
-  );
+  const handlePointerMove = (e: MainThread.TouchEvent) => {
+    'main thread';
+    if (!draggingRef.current) return;
+    buildPosition(e.detail.x);
+    if (posRef.current) {
+      onUpdate?.(posRef.current);
+    }
+  };
 
-  const onPointerUp = useCallback(
-    (e: MainThread.TouchEvent) => {
-      'main thread';
-      draggingRef.current = false;
-      buildPosition(e.detail.x);
-      if (posRef.current) {
-        onMTSCommit?.(posRef.current);
-      }
-    },
-    [buildPosition, onMTSCommit],
-  );
+  const handlePointerUp = (e: MainThread.TouchEvent) => {
+    'main thread';
+    draggingRef.current = false;
+    buildPosition(e.detail.x);
+    if (posRef.current) {
+      onCommit?.(posRef.current);
+    }
+  };
 
-  const onElementLayoutChange = useCallback(
-    async (e: MainThread.LayoutChangeEvent) => {
-      'main thread';
-      elementWidthRef.current = e.detail.width;
-      const rect: { left: number } =
-        await e.currentTarget.invoke('boundingClientRect');
-      elementLeftRef.current = rect.left;
-    },
-    [],
-  );
+  const handleElementLayoutChange = async (e: MainThread.LayoutChangeEvent) => {
+    'main thread';
+    elementWidthRef.current = e.detail.width;
+    const rect: { left: number } =
+      await e.currentTarget.invoke('boundingClientRect');
+    elementLeftRef.current = rect.left;
+  };
 
   return {
-    onMTSPointerDown: onPointerDown,
-    onMTSPointerMove: onPointerMove,
-    onMTSPointerUp: onPointerUp,
-    onMTSElementLayoutChange: onElementLayoutChange,
+    handlePointerDown: handlePointerDown,
+    handlePointerMove: handlePointerMove,
+    handlePointerUp: handlePointerUp,
+    handleElementLayoutChange: handleElementLayoutChange,
   };
 }
 
-interface UseMTSPointerInteractionReturnValue {
-  onMTSPointerDown: (e: MainThread.TouchEvent) => void;
-  onMTSPointerMove: (e: MainThread.TouchEvent) => void;
-  onMTSPointerUp: (e: MainThread.TouchEvent) => void;
-  onMTSElementLayoutChange: (e: MainThread.LayoutChangeEvent) => Promise<void>;
-}
+type UsePointerInteractionReturnValue = UsePointerInteractionReturnValueBase<
+  MainThread.TouchEvent,
+  MainThread.LayoutChangeEvent
+>;
 
-export { useMTSPointerInteraction };
-export type {
-  PointerPosition,
-  UseMTSPointerInteractionProps,
-  UseMTSPointerInteractionReturnValue,
-};
+export { usePointerInteraction };
+export type { PointerPosition, UsePointerInteractionReturnValue };

--- a/src/components/btc/Slider.tsx
+++ b/src/components/btc/Slider.tsx
@@ -21,7 +21,6 @@ function Slider(props: SliderProps) {
     handlePointerMove,
     handlePointerUp,
     handleElementLayoutChange,
-    elementRef,
     ratio,
   } = useSlider(sliderProps);
 
@@ -37,7 +36,6 @@ function Slider(props: SliderProps) {
     >
       {/* Track Positioner */}
       <view
-        ref={elementRef}
         bindlayoutchange={handleElementLayoutChange}
         className="relative w-full h-full flex flex-row items-center"
       >

--- a/src/components/mtc/use-mtc-slider-signal.ts
+++ b/src/components/mtc/use-mtc-slider-signal.ts
@@ -1,10 +1,10 @@
 'main thread';
 
 import { useComputed, useSignal } from '@lynx-js/react/signals';
-import { useMTCPointerInteraction } from './use-mtc-pointer-interaction';
+import { usePointerInteraction } from './use-mtc-pointer-interaction';
 import type {
   PointerPosition,
-  UseMTCPointerInteractionReturnValue,
+  UsePointerInteractionReturnValue,
 } from './use-mtc-pointer-interaction';
 
 interface UseMTCSliderProps {
@@ -39,7 +39,7 @@ function useMTCSlider({
     return clamp(aligned, min, max);
   };
 
-  const pointerReturnedValue = useMTCPointerInteraction({
+  const pointerReturnedValue = usePointerInteraction({
     onUpdate: (pos) => {
       if (disabled) return;
       const next = quantize(pos);
@@ -64,7 +64,7 @@ function useMTCSlider({
   };
 }
 
-interface UseMTCSliderReturnValue extends UseMTCPointerInteractionReturnValue {
+interface UseMTCSliderReturnValue extends UsePointerInteractionReturnValue {
   value: number;
   ratio: number;
   min: number;

--- a/src/components/mtc/use-mtc-slider-state.ts
+++ b/src/components/mtc/use-mtc-slider-state.ts
@@ -1,10 +1,10 @@
 'main thread';
 
 import { useState } from '@lynx-js/react';
-import { useMTCPointerInteraction } from './use-mtc-pointer-interaction';
+import { usePointerInteraction } from './use-mtc-pointer-interaction';
 import type {
   PointerPosition,
-  UseMTCPointerInteractionReturnValue,
+  UsePointerInteractionReturnValue,
 } from './use-mtc-pointer-interaction';
 
 interface UseMTCSliderProps {
@@ -39,7 +39,7 @@ function useMTCSlider({
     return clamp(aligned, min, max);
   };
 
-  const pointerReturnedValue = useMTCPointerInteraction({
+  const pointerReturnedValue = usePointerInteraction({
     onUpdate: (pos) => {
       if (disabled) return;
       const next = quantize(pos);
@@ -65,7 +65,7 @@ function useMTCSlider({
   };
 }
 
-interface UseMTCSliderReturnValue extends UseMTCPointerInteractionReturnValue {
+interface UseMTCSliderReturnValue extends UsePointerInteractionReturnValue {
   value: number;
   ratio: number;
   min: number;

--- a/src/types/pointer.ts
+++ b/src/types/pointer.ts
@@ -1,0 +1,34 @@
+/** Pointer position in the element’s local frame. */
+interface PointerPosition {
+  /** Horizontal offset from element's left edge (px). Can be <0 or >width. */
+  offset: number;
+  /** offset / elementWidth. Can be <0 or >1. */
+  offsetRatio: number;
+  /** Measured width of the element (px). */
+  elementWidth: number;
+}
+
+/** Interaction callbacks. */
+interface UsePointerInteractionProps {
+  /** Fires during drag/move. */
+  onUpdate?: (pos: PointerPosition) => void;
+  /** Fires on pointer up (final value). */
+  onCommit?: (pos: PointerPosition) => void;
+}
+
+type UsePointerInteractionReturnValueBase<TTouch, TLayout> = {
+  /** Bind on CONTAINER (or ELEMENT if container === element): <view bindtouchstart={handlePointerDown} /> */
+  handlePointerDown: (e: TTouch) => void;
+  /** Bind on CONTAINER (or ELEMENT if container === element): <view bindtouchmove={handlePointerMove} /> */
+  handlePointerMove: (e: TTouch) => void;
+  /** Bind on CONTAINER (or ELEMENT if container===element): <view bindtouchend|bindtouchcancel={handlePointerUp} /> */
+  handlePointerUp: (e: TTouch) => void;
+  /** Bind on ELEMENT: <view bindlayoutchange={handleElementLayoutChange} /> */
+  handleElementLayoutChange: (e: TLayout) => void;
+};
+
+export type {
+  PointerPosition,
+  UsePointerInteractionProps,
+  UsePointerInteractionReturnValueBase,
+};


### PR DESCRIPTION
This PR aligns the APIs and refines type definitions across BTC, MTS, and MTC pointer interaction hooks.

- Unified API surface: all hooks now expose the same return handlers — handlePointerDown, handlePointerMove, handlePointerUp, and handleElementLayoutChange.

- Standardized signatures: all handler functions consistently return void. Removed unnecessary Promise<void> from MTS/MTC; async behavior is handled internally.

- Simplified usage: no additional refs are required, element metrics are managed internally via layout change events.
