### PR TITLE
fix(demos): unify handleChange naming & prop usage; remove unnecessary useCallback imports

### DIFF
--- a/src/demos/BTCMTSColorPicker.tsx
+++ b/src/demos/BTCMTSColorPicker.tsx
@@ -1,4 +1,4 @@
-import { root, runOnBackground, useCallback, useState } from '@lynx-js/react';
+import { root, runOnBackground, useState } from '@lynx-js/react';
 import { AppLayout } from '@/App';
 import { sleep } from '@/utils/sleep';
 
@@ -15,13 +15,10 @@ export function App() {
     199, 99, 72,
   ]);
 
-  const handleChange = useCallback(
-    (next: readonly [number, number, number]) => {
-      'main thread';
-      runOnBackground(setValue)(next);
-    },
-    [],
-  );
+  const handleChange = (next: readonly [number, number, number]) => {
+    'main thread';
+    runOnBackground(setValue)(next);
+  };
 
   return (
     <AppLayout

--- a/src/demos/BTCSlider.tsx
+++ b/src/demos/BTCSlider.tsx
@@ -1,4 +1,4 @@
-import { root, useCallback, useState } from '@lynx-js/react';
+import { root, useState } from '@lynx-js/react';
 import { AppLayout } from '@/App';
 
 import { HueSlider } from '@/components/btc/Slider';
@@ -13,9 +13,9 @@ if (__BACKGROUND__) {
 export function App() {
   const [value, setValue] = useState(199);
 
-  const onChange = useCallback((next: number) => {
+  function handleChange(next: number) {
     setValue(next);
-  }, []);
+  }
 
   return (
     <AppLayout title="BTC Slider" h={value} s={99} l={72}>
@@ -23,7 +23,7 @@ export function App() {
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-12">
-        <HueSlider initialValue={value} onChange={onChange} s={99} l={72} />
+        <HueSlider initialValue={value} onChange={handleChange} s={99} l={72} />
       </view>
     </AppLayout>
   );

--- a/src/demos/MTCColorPicker.tsx
+++ b/src/demos/MTCColorPicker.tsx
@@ -15,10 +15,10 @@ type Color = readonly [number, number, number];
 export function App() {
   const [value, setValue] = useState<Color>(() => [199, 99, 72]);
 
-  function handleChange(v: Color) {
+  const handleChange = (v: Color) => {
     'use background';
     setValue(v);
-  }
+  };
 
   return (
     <AppLayout

--- a/src/demos/MTCColorPickerState.tsx
+++ b/src/demos/MTCColorPickerState.tsx
@@ -15,10 +15,10 @@ type Color = readonly [number, number, number];
 export function App() {
   const [value, setValue] = useState<Color>(() => [199, 99, 72]);
 
-  function handleOnChange(v: Color) {
+  const handleChange = (v: Color) => {
     'use background';
     setValue(v);
-  }
+  };
 
   return (
     <AppLayout
@@ -33,7 +33,7 @@ export function App() {
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-48">
-        <ColorPicker initialValue={value} onChange={handleOnChange} />
+        <ColorPicker initialValue={value} onChange={handleChange} />
       </view>
     </AppLayout>
   );


### PR DESCRIPTION
- Unify change handler naming to handleChange across BTC/MTC demos.
- Replace useCallback handlers with plain functions; remove unused useCallback imports.