### PR TITLE
refactor: centralize math & quantization logic (MathUtils/MTSMathUtils)

### DIFF
--- a/src/components/btc/use-slider.ts
+++ b/src/components/btc/use-slider.ts
@@ -6,6 +6,8 @@ import type {
 
 import { useControllable } from './use-controllable';
 
+import { MathUtils } from '@/utils/math-utils';
+
 interface UseSliderProps {
   value?: number;
   initialValue?: number;
@@ -36,14 +38,10 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
   });
 
   const step = stepProp > 0 ? stepProp : 1;
-  const ratio = valueToRatio(value, min, max);
+  const ratio = MathUtils.valueToRatio(value, min, max);
 
   const quantize = ({ offsetRatio }: PointerPosition) => {
-    const span = max - min;
-    if (!Number.isFinite(span) || span <= 0) return min;
-    const raw = min + offsetRatio * span;
-    const aligned = Math.round((raw - min) / step) * step + min;
-    return clamp(aligned, min, max);
+    return MathUtils.quantizeFromRatio(offsetRatio, min, max, step);
   };
 
   const pointerReturnedValue = usePointerInteraction({
@@ -78,21 +76,6 @@ interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
   max: number;
   step: number;
   disabled: boolean;
-}
-
-function clamp(v: number, min: number, max: number): number {
-  // Ensure value stays within [min, max]
-  return Math.max(min, Math.min(max, v));
-}
-
-function clamp01(x: number) {
-  return x < 0 ? 0 : x > 1 ? 1 : x;
-}
-
-function valueToRatio(v: number, min: number, max: number) {
-  const span = max - min;
-  if (!Number.isFinite(span) || span <= 0) return 0;
-  return clamp01((v - min) / span);
 }
 
 export { useSlider };

--- a/src/components/mtc/use-mtc-slider-signal.ts
+++ b/src/components/mtc/use-mtc-slider-signal.ts
@@ -7,6 +7,8 @@ import type {
   UsePointerInteractionReturnValue,
 } from './use-mtc-pointer-interaction';
 
+import { MathUtils } from '@/utils/math-utils';
+
 interface UseSliderProps {
   initialValue?: number;
   min?: number;
@@ -27,16 +29,14 @@ function useSlider({
   onCommit,
 }: UseSliderProps) {
   const value = useSignal(initialValue);
-  const ratio = useComputed(() => valueToRatio(value.value, min, max));
+  const ratio = useComputed(() =>
+    MathUtils.valueToRatio(value.value, min, max),
+  );
 
   const step = stepProp > 0 ? stepProp : 1;
 
   const quantize = ({ offsetRatio }: PointerPosition) => {
-    const span = max - min;
-    if (!Number.isFinite(span) || span <= 0) return min;
-    const raw = min + offsetRatio * span;
-    const aligned = Math.round((raw - min) / step) * step + min;
-    return clamp(aligned, min, max);
+    return MathUtils.quantizeFromRatio(offsetRatio, min, max, step);
   };
 
   const pointerReturnedValue = usePointerInteraction({
@@ -71,21 +71,6 @@ interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
   max: number;
   step: number;
   disabled: boolean;
-}
-
-function clamp(v: number, min: number, max: number): number {
-  // Ensure value stays within [min, max]
-  return Math.max(min, Math.min(max, v));
-}
-
-function clamp01(x: number) {
-  return x < 0 ? 0 : x > 1 ? 1 : x;
-}
-
-function valueToRatio(v: number, min: number, max: number) {
-  const span = max - min;
-  if (!Number.isFinite(span) || span <= 0) return 0;
-  return clamp01((v - min) / span);
 }
 
 export { useSlider };

--- a/src/components/mtc/use-mtc-slider-state.ts
+++ b/src/components/mtc/use-mtc-slider-state.ts
@@ -7,6 +7,8 @@ import type {
   UsePointerInteractionReturnValue,
 } from './use-mtc-pointer-interaction';
 
+import { MathUtils } from '@/utils/math-utils';
+
 interface UseSliderProps {
   initialValue?: number;
   min?: number;
@@ -28,15 +30,11 @@ function useSlider({
 }: UseSliderProps) {
   const [value, setValue] = useState(initialValue);
 
-  const ratio = valueToRatio(value, min, max);
+  const ratio = MathUtils.valueToRatio(value, min, max);
   const step = stepProp > 0 ? stepProp : 1;
 
   const quantize = ({ offsetRatio }: PointerPosition) => {
-    const span = max - min;
-    if (!Number.isFinite(span) || span <= 0) return min;
-    const raw = min + offsetRatio * span;
-    const aligned = Math.round((raw - min) / step) * step + min;
-    return clamp(aligned, min, max);
+    return MathUtils.quantizeFromRatio(offsetRatio, min, max, step);
   };
 
   const pointerReturnedValue = usePointerInteraction({
@@ -72,21 +70,6 @@ interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
   max: number;
   step: number;
   disabled: boolean;
-}
-
-function clamp(v: number, min: number, max: number): number {
-  // Ensure value stays within [min, max]
-  return Math.max(min, Math.min(max, v));
-}
-
-function clamp01(x: number) {
-  return x < 0 ? 0 : x > 1 ? 1 : x;
-}
-
-function valueToRatio(v: number, min: number, max: number) {
-  const span = max - min;
-  if (!Number.isFinite(span) || span <= 0) return 0;
-  return clamp01((v - min) / span);
 }
 
 export { useSlider };

--- a/src/utils/math-utils.ts
+++ b/src/utils/math-utils.ts
@@ -1,0 +1,52 @@
+/** Clamp value into [min, max]. */
+function clamp(v: number, min: number, max: number): number {
+  // Ensure value stays within [min, max]
+  return Math.max(min, Math.min(max, v));
+}
+
+/** Map absolute value -> [0,1] ratio within [min, max]. */
+function valueToRatio(v: number, min: number, max: number) {
+  const span = max - min;
+  if (!Number.isFinite(span) || span <= 0) return 0;
+  return clamp((v - min) / span, 0, 1);
+}
+
+/** Map [0,1] ratio -> absolute value within [min, max]. */
+export function ratioToValue(ratio: number, min: number, max: number): number {
+  const r = clamp(ratio, 0, 1);
+  return min + r * (max - min);
+}
+
+/** Quantize an absolute value to a step grid anchored at `min`, then clamp. */
+export function quantizeValue(
+  value: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  const span = max - min;
+  if (!Number.isFinite(span) || span <= 0) return min;
+  if (!Number.isFinite(step) || step <= 0) return clamp(value, min, max);
+
+  const k = Math.round((value - min) / step);
+  const aligned = min + k * step;
+  return clamp(aligned, min, max);
+}
+
+/** Quantize from a ratio ([0,1]) with [min,max] & step. */
+export function quantizeFromRatio(
+  offsetRatio: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  const raw = ratioToValue(offsetRatio, min, max);
+  return quantizeValue(raw, min, max, step);
+}
+
+/* ===================== Namespace ===================== */
+export const MathUtils = {
+  valueToRatio,
+  clamp,
+  quantizeFromRatio,
+};

--- a/src/utils/mts-math-utils.ts
+++ b/src/utils/mts-math-utils.ts
@@ -1,0 +1,57 @@
+/** Clamp value into [min, max]. */
+function clamp(v: number, min: number, max: number): number {
+  'main thread';
+  // Ensure value stays within [min, max]
+  return Math.max(min, Math.min(max, v));
+}
+
+/** Map absolute value -> [0,1] ratio within [min, max]. */
+function valueToRatio(v: number, min: number, max: number) {
+  'main thread';
+  const span = max - min;
+  if (!Number.isFinite(span) || span <= 0) return 0;
+  return clamp((v - min) / span, 0, 1);
+}
+
+/** Map [0,1] ratio -> absolute value within [min, max]. */
+export function ratioToValue(ratio: number, min: number, max: number): number {
+  'main thread';
+  const r = clamp(ratio, 0, 1);
+  return min + r * (max - min);
+}
+
+/** Quantize an absolute value to a step grid anchored at `min`, then clamp. */
+export function quantizeValue(
+  value: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  'main thread';
+  const span = max - min;
+  if (!Number.isFinite(span) || span <= 0) return min;
+  if (!Number.isFinite(step) || step <= 0) return clamp(value, min, max);
+
+  const k = Math.round((value - min) / step);
+  const aligned = min + k * step;
+  return clamp(aligned, min, max);
+}
+
+/** Quantize from a ratio ([0,1]) with [min,max] & step. */
+export function quantizeFromRatio(
+  offsetRatio: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  'main thread';
+  const raw = ratioToValue(offsetRatio, min, max);
+  return quantizeValue(raw, min, max, step);
+}
+
+/* ===================== Namespace ===================== */
+export const MTSMathUtils = {
+  valueToRatio,
+  clamp,
+  quantizeFromRatio,
+};


### PR DESCRIPTION
- Add `MathUtils` with `clamp`, `valueToRatio`, `ratioToValue`, `quantizeValue`, `quantizeFromRatio`.
- Add `MTSMathUtils`: function-scoped `'main thread'` implementations (no delegation/wrappers).
- Replace duplicated quantize code in sliders with util calls.
- No behavior changes; demos updated only for imports/usages.