### PR TITLE
refactor: unify shared types and simplify API

### DIFF
--- a/src/components/btc-mts/BTCMTSColorPicker.tsx
+++ b/src/components/btc-mts/BTCMTSColorPicker.tsx
@@ -7,8 +7,7 @@ import {
 } from '@lynx-js/react';
 import { HueSlider, LightnessSlider, SaturationSlider } from './BTCMTSSlider';
 import { HSLGradients } from '@/utils/hsl-gradients';
-
-type Color = readonly [number, number, number];
+import type { Color } from '@/types/color';
 
 interface ColorPickerProps {
   initialValue?: Color;

--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -6,7 +6,7 @@ import type { Expand, RenameKeys } from '@/types/utils';
 
 type SliderProps = Expand<
   RenameKeys<
-    Omit<UseSliderProps, 'onCommit' | 'onDerivedChange'>,
+    Omit<UseSliderProps, 'onDerivedChange'>,
     {
       onChange?: 'main-thread:onChange';
       writeValue?: 'main-thread:writeValue';

--- a/src/components/btc-mts/MTSColorPicker.tsx
+++ b/src/components/btc-mts/MTSColorPicker.tsx
@@ -2,25 +2,24 @@ import { useCallback, useMainThreadRef } from '@lynx-js/react';
 import { HueSlider, LightnessSlider, SaturationSlider } from './MTSSlider';
 import type { Writer } from './MTSSlider';
 
-type Color = readonly [number, number, number];
-type Vector2 = readonly [number, number];
+import type { HSL, Vec2 } from '@/types/color';
 
 interface ColorPickerProps {
-  initialValue?: Color;
-  'main-thread:onChange'?: (next: Color) => void;
+  initialValue?: HSL;
+  'main-thread:onChange'?: (next: HSL) => void;
 }
 function ColorPicker({
   initialValue: hsl = [199, 99, 72],
   ['main-thread:onChange']: onChange,
 }: ColorPickerProps) {
   const hueRef = useMainThreadRef(hsl[0]);
-  const writeSL = useMainThreadRef<Writer<Vector2>>();
+  const writeSL = useMainThreadRef<Writer<Vec2>>();
 
   const satRef = useMainThreadRef(hsl[1]);
-  const writeHL = useMainThreadRef<Writer<Vector2>>();
+  const writeHL = useMainThreadRef<Writer<Vec2>>();
 
   const lightRef = useMainThreadRef(hsl[2]);
-  const writeHS = useMainThreadRef<Writer<Vector2>>();
+  const writeHS = useMainThreadRef<Writer<Vec2>>();
 
   const writeSliderGradients = useCallback(() => {
     'main thread';

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -14,10 +14,11 @@ import { resolveNextValue } from './use-mts-controllable';
 import { HSLGradients } from '@/utils/hsl-gradients';
 import { MTSHSLGradients } from '@/utils/mts-hsl-gradients';
 import type { Expand, RenameKeys } from '@/types/utils';
+import type { Vec2 } from '@/types/color';
 
 type SliderProps = Expand<
   RenameKeys<
-    Omit<UseSliderProps, 'onCommit' | 'onDerivedChange'>,
+    Omit<UseSliderProps, 'onDerivedChange'>,
     {
       onChange?: 'main-thread:onChange';
     }
@@ -178,33 +179,21 @@ function Slider(props: SliderProps) {
   );
 }
 
-/** ================= HSL Sliders Shared ================= */
-
-type HSLBaseSliderProps = Pick<
-  SliderProps,
-  'initialValue' | 'main-thread:onChange' | 'disabled' | 'writeValue'
->;
-
 /** ================= Hue Slider ================= */
 
 function HueSlider({
   initialSL = [100, 50],
   ['main-thread:writeSL']: writeSL,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    initialSL?: readonly [number, number];
-    ['main-thread:writeSL']?: WriterRef<readonly [number, number]>;
-  }
->) {
+}: HueSliderProps) {
   const [gradients] = useState(() => {
     return HSLGradients.hueGradientPair(initialSL[0], initialSL[1]);
   });
-  const currentSLRef = useMainThreadRef<readonly [number, number]>(initialSL);
+  const currentSLRef = useMainThreadRef<Vec2>(initialSL);
   const writeRootStyle = useMainThreadRef<Writer<Record<string, string>>>();
   const writeTrackStyle = useMainThreadRef<Writer<Record<string, string>>>();
 
-  const updateStyle = (next: RefWriteAction<readonly [number, number]>) => {
+  const updateStyle = (next: RefWriteAction<Vec2>) => {
     'main thread';
     const resolved = resolveNextValue(currentSLRef.current, next);
     if (resolved !== undefined) {
@@ -244,22 +233,17 @@ function SaturationSlider({
   initialHL = [0, 50],
   ['main-thread:writeHL']: writeHL,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    initialHL?: readonly [number, number];
-    ['main-thread:writeHL']?: WriterRef<readonly [number, number]>;
-  }
->) {
+}: SaturationSliderProps) {
   const [gradients] = useState(() => {
     return HSLGradients.saturationGradientPair(initialHL[0], initialHL[1]);
   });
 
-  const currentHLRef = useMainThreadRef<readonly [number, number]>(initialHL);
+  const currentHLRef = useMainThreadRef<Vec2>(initialHL);
 
   const writeRootStyle = useMainThreadRef<Writer<Record<string, string>>>();
   const writeTrackStyle = useMainThreadRef<Writer<Record<string, string>>>();
 
-  const updateStyle = (next: RefWriteAction<readonly [number, number]>) => {
+  const updateStyle = (next: RefWriteAction<Vec2>) => {
     'main thread';
     const resolved = resolveNextValue(currentHLRef.current, next);
     if (resolved !== undefined) {
@@ -298,22 +282,17 @@ function LightnessSlider({
   initialHS = [0, 100],
   ['main-thread:writeHS']: writeHS,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    initialHS?: readonly [number, number];
-    ['main-thread:writeHS']?: WriterRef<readonly [number, number]>;
-  }
->) {
+}: LightnessSliderProps) {
   const [gradients] = useState(() => {
     return HSLGradients.lightnessGradientPair(initialHS[0], initialHS[1]);
   });
 
-  const currentHSRef = useMainThreadRef<readonly [number, number]>(initialHS);
+  const currentHSRef = useMainThreadRef<Vec2>(initialHS);
 
   const writeRootStyle = useMainThreadRef<Writer<Record<string, string>>>();
   const writeTrackStyle = useMainThreadRef<Writer<Record<string, string>>>();
 
-  const updateStyle = (next: RefWriteAction<readonly [number, number]>) => {
+  const updateStyle = (next: RefWriteAction<Vec2>) => {
     'main thread';
     const resolved = resolveNextValue(currentHSRef.current, next);
     if (resolved !== undefined) {
@@ -348,3 +327,31 @@ function LightnessSlider({
 
 export { Slider, HueSlider, LightnessSlider, SaturationSlider };
 export type { WriterRef, Writer, WriterWithControls, WriterWithControlsRef };
+
+/** ================= HSL Sliders Shared Types ================= */
+
+type StyledSliderProps = Pick<
+  SliderProps,
+  'initialValue' | 'main-thread:onChange' | 'disabled' | 'writeValue'
+>;
+
+type HueSliderProps = Expand<
+  StyledSliderProps & {
+    initialSL?: Vec2;
+    ['main-thread:writeSL']?: WriterRef<Vec2>;
+  }
+>;
+
+type LightnessSliderProps = Expand<
+  StyledSliderProps & {
+    initialHS?: Vec2;
+    ['main-thread:writeHS']?: WriterRef<Vec2>;
+  }
+>;
+
+type SaturationSliderProps = Expand<
+  StyledSliderProps & {
+    initialHL?: Vec2;
+    ['main-thread:writeHL']?: WriterRef<Vec2>;
+  }
+>;

--- a/src/components/btc-mts/use-mts-slider.ts
+++ b/src/components/btc-mts/use-mts-slider.ts
@@ -17,18 +17,24 @@ import type {
 import { MTSMathUtils } from '@/utils/mts-math-utils';
 import { MathUtils } from '@/utils/math-utils';
 
-interface UseSliderProps {
-  writeValue?: WriterWithControlsRef<number>;
-  initialValue?: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  disabled?: boolean;
+import type {
+  UseSliderPropsBase,
+  UseSliderReturnValueBase,
+} from '@/types/slider';
 
+type UseSliderProps = UseSliderPropsBase<{
+  writeValue?: WriterWithControlsRef<number>;
   onDerivedChange?: (value: number) => void;
-  onChange?: (value: number) => void;
-  onCommit?: (value: number) => void;
-}
+}>;
+
+type UseSliderReturnValue = UseSliderReturnValueBase<
+  UsePointerInteractionReturnValue,
+  {
+    writeValue: WriterWithControls<number>;
+    valueRef: MainThreadRef<number>;
+    ratioRef: MainThreadRef<number>;
+  }
+>;
 
 function useSlider(props: UseSliderProps): UseSliderReturnValue {
   const {
@@ -40,7 +46,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
     disabled = false,
     onDerivedChange,
     onChange,
-    onCommit,
   } = props;
 
   const step = stepProp > 0 ? stepProp : 1;
@@ -84,16 +89,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
     [disabled, quantize, writeValue],
   );
 
-  const handlePointerCommit = (pos: PointerPosition) => {
-    ('main thread');
-    if (disabled) return;
-    const next = quantize(pos);
-    // Controlled: only notify change;
-    // Uncontrolled: update internals and notify change;
-    writeValue(next);
-    onCommit?.(next);
-  };
-
   const {
     handlePointerDown,
     handlePointerMove,
@@ -101,7 +96,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
     handleElementLayoutChange,
   } = usePointerInteraction({
     onUpdate: handlePointerUpdate,
-    onCommit: handlePointerCommit,
   });
 
   return {
@@ -117,16 +111,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
     handlePointerUp,
     handleElementLayoutChange,
   };
-}
-
-interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
-  writeValue: WriterWithControls<number>;
-  valueRef: MainThreadRef<number>;
-  ratioRef: MainThreadRef<number>;
-  min: number;
-  max: number;
-  step: number;
-  disabled: boolean;
 }
 
 export { useSlider };

--- a/src/components/btc/Slider.tsx
+++ b/src/components/btc/Slider.tsx
@@ -59,7 +59,6 @@ function HueSlider({
   s = 100,
   l = 50,
   onChange,
-  onCommit,
   disabled,
 }: {
   value?: number;
@@ -67,7 +66,6 @@ function HueSlider({
   s?: number;
   l?: number;
   onChange?: (h: number) => void;
-  onCommit?: (h: number) => void;
   disabled?: boolean;
 }) {
   const { track: trackBg, edge: edgeBg } = useMemo(
@@ -84,7 +82,6 @@ function HueSlider({
       step={1}
       disabled={disabled}
       onChange={onChange}
-      onCommit={onCommit}
       rootStyle={{ backgroundImage: edgeBg }}
       trackStyle={{ backgroundImage: trackBg }}
     />

--- a/src/components/btc/use-slider.ts
+++ b/src/components/btc/use-slider.ts
@@ -8,16 +8,14 @@ import { useControllable } from './use-controllable';
 
 import { MathUtils } from '@/utils/math-utils';
 
-interface UseSliderProps {
-  value?: number;
-  initialValue?: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  disabled?: boolean;
-  onChange?: (value: number) => void;
-  onCommit?: (value: number) => void;
-}
+import type {
+  UseSliderPropsBase,
+  UseSliderReturnValueBase,
+} from '@/types/slider';
+
+type UseSliderProps = UseSliderPropsBase<{ value?: number }>;
+type UseSliderReturnValue =
+  UseSliderReturnValueBase<UsePointerInteractionReturnValue>;
 
 function useSlider(props: UseSliderProps): UseSliderReturnValue {
   const {
@@ -28,7 +26,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
     initialValue = min,
     disabled = false,
     onChange,
-    onCommit,
   } = props;
 
   const [value = initialValue, setValue] = useControllable<number>({
@@ -50,12 +47,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
       const next = quantize(pos);
       setValue(next);
     },
-    onCommit: (pos) => {
-      if (disabled) return;
-      const next = quantize(pos);
-      setValue(next);
-      onCommit?.(next);
-    },
   });
 
   return {
@@ -67,15 +58,6 @@ function useSlider(props: UseSliderProps): UseSliderReturnValue {
     disabled,
     ...pointerReturnedValue,
   };
-}
-
-interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
-  value: number;
-  ratio: number;
-  min: number;
-  max: number;
-  step: number;
-  disabled: boolean;
 }
 
 export { useSlider };

--- a/src/components/mtc/MTCColorPickerSignal.tsx
+++ b/src/components/mtc/MTCColorPickerSignal.tsx
@@ -6,11 +6,11 @@ import {
   LightnessSlider,
 } from './MTCSliderSignal';
 
-type Color = readonly [number, number, number];
+import type { HSL } from '@/types/color';
 
 interface ColorPickerProps {
-  initialValue: Color;
-  onChange?: (next: Color) => void;
+  initialValue: HSL;
+  onChange?: (next: HSL) => void;
 }
 
 function ColorPicker({ initialValue, onChange }: ColorPickerProps) {

--- a/src/components/mtc/MTCColorPickerState.tsx
+++ b/src/components/mtc/MTCColorPickerState.tsx
@@ -2,11 +2,11 @@
 import { useState } from '@lynx-js/react';
 import { HueSlider, SaturationSlider, LightnessSlider } from './MTCSliderState';
 
-type Color = readonly [number, number, number];
+import type { HSL } from '@/types/color';
 
 interface ColorPickerProps {
-  initialValue: Color;
-  onChange?: (next: Color) => void;
+  initialValue: HSL;
+  onChange?: (next: HSL) => void;
 }
 
 function ColorPicker({ initialValue, onChange }: ColorPickerProps) {

--- a/src/components/mtc/MTCSliderSignal.tsx
+++ b/src/components/mtc/MTCSliderSignal.tsx
@@ -1,12 +1,18 @@
 'main thread';
 
-import { useComputed, useSignal, signal } from '@lynx-js/react/signals';
+import { useComputed, signal } from '@lynx-js/react/signals';
 import type { CSSProperties } from '@lynx-js/types';
 
 import { useSlider } from './use-mtc-slider-signal';
 import type { UseSliderProps } from './use-mtc-slider-signal';
 import { HSLGradients } from '@/utils/hsl-gradients';
 import type { Expand } from '@/types/utils';
+import type { ReadonlySignal } from '@/types/signals';
+
+import type {
+  StyledSliderPropsBase,
+  HSLSliderPropsBase,
+} from '@/types/hsl-slider';
 
 type SliderProps = Expand<
   UseSliderProps & {
@@ -61,11 +67,6 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
 
 /** ================== HSL Sliders Shared ================= */
 
-type HSLBaseSliderProps = Omit<
-  SliderProps,
-  'min' | 'max' | 'step' | 'trackStyle' | 'rootStyle'
->;
-
 const defaultHue = signal(0);
 const defaultSaturation = signal(100);
 const defaultLightness = signal(50);
@@ -76,12 +77,7 @@ function HueSlider({
   s = defaultSaturation,
   l = defaultLightness,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    s?: ReturnType<typeof useSignal<number>>;
-    l?: ReturnType<typeof useSignal<number>>;
-  }
->) {
+}: HueSliderProps) {
   const gradients = useComputed(() =>
     HSLGradients.hueGradientPair(
       s.value ?? defaultSaturation.value,
@@ -107,12 +103,7 @@ function SaturationSlider({
   h = defaultHue,
   l = defaultLightness,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    h?: ReturnType<typeof useSignal<number>>;
-    l?: ReturnType<typeof useSignal<number>>;
-  }
->) {
+}: SaturationSliderProps) {
   const gradients = useComputed(() =>
     HSLGradients.saturationGradientPair(
       h.value ?? defaultHue.value,
@@ -138,10 +129,7 @@ function LightnessSlider({
   h = defaultHue,
   s = defaultSaturation,
   ...restProps
-}: Expand<Omit<SliderProps, 'min' | 'max' | 'step'>> & {
-  h?: ReturnType<typeof useSignal<number>>;
-  s?: ReturnType<typeof useSignal<number>>;
-}) {
+}: LightnessSliderProps) {
   const gradients = useComputed(() =>
     HSLGradients.lightnessGradientPair(
       h.value ?? defaultHue.value,
@@ -162,3 +150,29 @@ function LightnessSlider({
 }
 
 export { Slider, HueSlider, SaturationSlider, LightnessSlider };
+
+/** ================= HSL Sliders Shared Types ================= */
+type StyledSliderProps = StyledSliderPropsBase<
+  SliderProps,
+  'trackStyle' | 'rootStyle'
+>;
+
+type HueSliderProps = HSLSliderPropsBase<
+  StyledSliderProps,
+  ReadonlySignal<number>,
+  's',
+  'l'
+>;
+type SaturationSliderProps = HSLSliderPropsBase<
+  StyledSliderProps,
+  ReadonlySignal<number>,
+  'h',
+  'l'
+>;
+
+type LightnessSliderProps = HSLSliderPropsBase<
+  StyledSliderProps,
+  ReadonlySignal<number>,
+  'h',
+  's'
+>;

--- a/src/components/mtc/MTCSliderState.tsx
+++ b/src/components/mtc/MTCSliderState.tsx
@@ -6,6 +6,11 @@ import type { UseSliderProps } from './use-mtc-slider-state';
 import { HSLGradients } from '@/utils/hsl-gradients';
 import type { Expand } from '@/types/utils';
 
+import type {
+  StyledSliderPropsBase,
+  HSLSliderPropsBase,
+} from '@/types/hsl-slider';
+
 type SliderProps = Expand<
   UseSliderProps & {
     // Styling
@@ -61,11 +66,6 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
 
 /** ================= HSL Sliders Shared ================= */
 
-type HSLBaseSliderProps = Omit<
-  SliderProps,
-  'min' | 'max' | 'step' | 'trackStyle' | 'rootStyle'
->;
-
 const defaultHue = 0;
 const defaultSaturation = 100;
 const defaultLightness = 50;
@@ -76,12 +76,7 @@ function HueSlider({
   s = defaultSaturation,
   l = defaultLightness,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    s?: number;
-    l?: number;
-  }
->) {
+}: HueSliderProps) {
   const gradients = HSLGradients.hueGradientPair(s, l);
 
   return (
@@ -102,12 +97,7 @@ function SaturationSlider({
   h = defaultHue,
   l = defaultLightness,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    h?: number;
-    l?: number;
-  }
->) {
+}: SaturationSliderProps) {
   const gradients = HSLGradients.saturationGradientPair(h, l);
 
   return (
@@ -128,12 +118,7 @@ function LightnessSlider({
   h = defaultHue,
   s = defaultSaturation,
   ...restProps
-}: Expand<
-  HSLBaseSliderProps & {
-    h?: number;
-    s?: number;
-  }
->) {
+}: LightnessSliderProps) {
   const gradients = HSLGradients.lightnessGradientPair(h, s);
 
   return (
@@ -149,3 +134,25 @@ function LightnessSlider({
 }
 
 export { Slider, HueSlider, SaturationSlider, LightnessSlider };
+
+/** ================= HSL Sliders Shared Types ================= */
+
+type StyledSliderProps = StyledSliderPropsBase<
+  SliderProps,
+  'trackStyle' | 'rootStyle'
+>;
+
+type HueSliderProps = HSLSliderPropsBase<StyledSliderProps, number, 's', 'l'>;
+type SaturationSliderProps = HSLSliderPropsBase<
+  StyledSliderProps,
+  number,
+  'h',
+  'l'
+>;
+
+type LightnessSliderProps = HSLSliderPropsBase<
+  StyledSliderProps,
+  number,
+  'h',
+  's'
+>;

--- a/src/components/mtc/use-mtc-slider-signal.ts
+++ b/src/components/mtc/use-mtc-slider-signal.ts
@@ -9,15 +9,18 @@ import type {
 
 import { MathUtils } from '@/utils/math-utils';
 
-interface UseSliderProps {
-  initialValue?: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  disabled?: boolean;
-  onChange?: (value: number) => void;
-  onCommit?: (value: number) => void;
-}
+import type {
+  UseSliderPropsBase,
+  UseSliderReturnValueBase,
+} from '@/types/slider';
+
+import type { Signal, ReadonlySignal } from '@/types/signals';
+
+type UseSliderProps = UseSliderPropsBase;
+type UseSliderReturnValue = UseSliderReturnValueBase<
+  UsePointerInteractionReturnValue,
+  { value: Signal<number>; ratio: ReadonlySignal<number> }
+>;
 
 function useSlider({
   min = 0,
@@ -26,8 +29,7 @@ function useSlider({
   initialValue = min,
   disabled = false,
   onChange,
-  onCommit,
-}: UseSliderProps) {
+}: UseSliderProps): UseSliderReturnValue {
   const value = useSignal(initialValue);
   const ratio = useComputed(() =>
     MathUtils.valueToRatio(value.value, min, max),
@@ -46,12 +48,6 @@ function useSlider({
       value.value = next;
       onChange?.(next);
     },
-    onCommit: (pos) => {
-      if (disabled) return;
-      const next = quantize(pos);
-      value.value = next;
-      onCommit?.(next);
-    },
   });
   return {
     value,
@@ -62,15 +58,6 @@ function useSlider({
     disabled,
     ...pointerReturnedValue,
   };
-}
-
-interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
-  value: number;
-  ratio: number;
-  min: number;
-  max: number;
-  step: number;
-  disabled: boolean;
 }
 
 export { useSlider };

--- a/src/components/mtc/use-mtc-slider-state.ts
+++ b/src/components/mtc/use-mtc-slider-state.ts
@@ -9,15 +9,14 @@ import type {
 
 import { MathUtils } from '@/utils/math-utils';
 
-interface UseSliderProps {
-  initialValue?: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  disabled?: boolean;
-  onChange?: (value: number) => void;
-  onCommit?: (value: number) => void;
-}
+import type {
+  UseSliderPropsBase,
+  UseSliderReturnValueBase,
+} from '@/types/slider';
+
+type UseSliderProps = UseSliderPropsBase;
+type UseSliderReturnValue =
+  UseSliderReturnValueBase<UsePointerInteractionReturnValue>;
 
 function useSlider({
   min = 0,
@@ -26,8 +25,7 @@ function useSlider({
   initialValue = min,
   disabled = false,
   onChange,
-  onCommit,
-}: UseSliderProps) {
+}: UseSliderProps): UseSliderReturnValue {
   const [value, setValue] = useState(initialValue);
 
   const ratio = MathUtils.valueToRatio(value, min, max);
@@ -44,12 +42,6 @@ function useSlider({
       setValue(next);
       onChange?.(next);
     },
-    onCommit: (pos) => {
-      if (disabled) return;
-      const next = quantize(pos);
-      setValue(next);
-      onCommit?.(next);
-    },
   });
 
   return {
@@ -61,15 +53,6 @@ function useSlider({
     disabled,
     ...pointerReturnedValue,
   };
-}
-
-interface UseSliderReturnValue extends UsePointerInteractionReturnValue {
-  value: number;
-  ratio: number;
-  min: number;
-  max: number;
-  step: number;
-  disabled: boolean;
 }
 
 export { useSlider };

--- a/src/demos/BTCBTCMTSColorPicker.tsx
+++ b/src/demos/BTCBTCMTSColorPicker.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from '@/App';
 import { sleep } from '@/utils/sleep';
 
 import { ColorPicker } from '@/components/btc-mts/BTCMTSColorPicker';
+import type { HSL } from '@/types/color';
 
 if (__BACKGROUND__) {
   setInterval(() => {
@@ -11,9 +12,7 @@ if (__BACKGROUND__) {
 }
 
 export function App() {
-  const [value, setValue] = useState<readonly [number, number, number]>([
-    199, 99, 72,
-  ]);
+  const [value, setValue] = useState<HSL>([199, 99, 72]);
 
   return (
     <AppLayout

--- a/src/demos/BTCMTSColorPicker.tsx
+++ b/src/demos/BTCMTSColorPicker.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from '@/App';
 import { sleep } from '@/utils/sleep';
 
 import { ColorPicker } from '@/components/btc-mts/MTSColorPicker';
+import type { HSL } from '@/types/color';
 
 if (__BACKGROUND__) {
   setInterval(() => {
@@ -11,11 +12,9 @@ if (__BACKGROUND__) {
 }
 
 export function App() {
-  const [value, setValue] = useState<readonly [number, number, number]>([
-    199, 99, 72,
-  ]);
+  const [value, setValue] = useState<HSL>([199, 99, 72]);
 
-  const handleChange = (next: readonly [number, number, number]) => {
+  const handleChange = (next: HSL) => {
     'main thread';
     runOnBackground(setValue)(next);
   };

--- a/src/demos/BTCSlider.tsx
+++ b/src/demos/BTCSlider.tsx
@@ -13,9 +13,9 @@ if (__BACKGROUND__) {
 export function App() {
   const [value, setValue] = useState(199);
 
-  function handleChange(next: number) {
+  const handleChange = (next: number) => {
     setValue(next);
-  }
+  };
 
   return (
     <AppLayout title="BTC Slider" h={value} s={99} l={72}>

--- a/src/demos/MTCColorPicker.tsx
+++ b/src/demos/MTCColorPicker.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from '@/App';
 import { ColorPicker } from '@/components/mtc/MTCColorPickerSignal';
 import { DummyStyle } from '@/components/ui/DummyStyle';
 import { sleep } from '@/utils/sleep';
+import type { HSL } from '@/types/color';
 
 if (__BACKGROUND__) {
   setInterval(() => {
@@ -10,12 +11,10 @@ if (__BACKGROUND__) {
   }, 100);
 }
 
-type Color = readonly [number, number, number];
-
 export function App() {
-  const [value, setValue] = useState<Color>(() => [199, 99, 72]);
+  const [value, setValue] = useState<HSL>(() => [199, 99, 72]);
 
-  const handleChange = (v: Color) => {
+  const handleChange = (v: HSL) => {
     'use background';
     setValue(v);
   };

--- a/src/demos/MTCColorPickerState.tsx
+++ b/src/demos/MTCColorPickerState.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from '@/App';
 import { ColorPicker } from '@/components/mtc/MTCColorPickerState';
 import { DummyStyle } from '@/components/ui/DummyStyle';
 import { sleep } from '@/utils/sleep';
+import type { HSL } from '@/types/color';
 
 if (__BACKGROUND__) {
   setInterval(() => {
@@ -10,12 +11,10 @@ if (__BACKGROUND__) {
   }, 100);
 }
 
-type Color = readonly [number, number, number];
-
 export function App() {
-  const [value, setValue] = useState<Color>(() => [199, 99, 72]);
+  const [value, setValue] = useState<HSL>(() => [199, 99, 72]);
 
-  const handleChange = (v: Color) => {
+  const handleChange = (v: HSL) => {
     'use background';
     setValue(v);
   };

--- a/src/types/color.ts
+++ b/src/types/color.ts
@@ -1,0 +1,7 @@
+type Vec2 = readonly [number, number];
+type Vec3 = readonly [number, number, number];
+
+type HSL = Vec3;
+type Color = Vec3;
+
+export type { Color, HSL, Vec2 };

--- a/src/types/hsl-slider.ts
+++ b/src/types/hsl-slider.ts
@@ -1,0 +1,21 @@
+import type { Expand, OmitKeys } from './utils';
+
+type StyledSliderPropsBase<
+  P extends object = {},
+  SK extends string = 'trackStyle' | 'rootStyle',
+> = OmitKeys<P, 'min' | 'max' | 'step' | SK>;
+
+type HSLValue<T> = {
+  h?: T;
+  s?: T;
+  l?: T;
+};
+
+type HSLSliderPropsBase<
+  S,
+  V,
+  T extends keyof HSLValue<V>,
+  K extends keyof HSLValue<V>,
+> = Expand<S & Pick<HSLValue<V>, T | K>>;
+
+export type { StyledSliderPropsBase, HSLSliderPropsBase };

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -1,0 +1,6 @@
+import { signal, computed } from '@lynx-js/react/signals';
+
+type ReadonlySignal<T> = ReturnType<typeof computed<T>>;
+type Signal<T> = ReturnType<typeof signal<T>>;
+
+export type { Signal, ReadonlySignal };

--- a/src/types/slider.ts
+++ b/src/types/slider.ts
@@ -1,0 +1,39 @@
+import type { Expand } from '@/types/utils';
+
+type SliderCoreProps = {
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+};
+
+type ResolvedSliderCore = Readonly<{
+  min: number;
+  max: number;
+  step: number;
+  disabled: boolean;
+}>;
+
+type UseSliderPropsBase<TExtra = {}> = Expand<
+  SliderCoreProps & {
+    initialValue?: number;
+    onChange?: (value: number) => void;
+  } & TExtra
+>;
+
+type SliderReturnValueState = {
+  value: number;
+  ratio: number;
+};
+
+type UseSliderReturnValueBase<
+  TPointerReturnValue,
+  TSliderReturnValue = SliderReturnValueState,
+> = Expand<TPointerReturnValue & TSliderReturnValue & ResolvedSliderCore>;
+
+export type {
+  SliderCoreProps,
+  ResolvedSliderCore,
+  UseSliderPropsBase,
+  UseSliderReturnValueBase,
+};

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -8,3 +8,5 @@ export type RenameKeys<T, Map extends Record<string, PropertyKey>> = Omit<
   T,
   keyof Map
 > & { [K in keyof Map as Map[K]]: K extends keyof T ? T[K] : never };
+
+export type OmitKeys<P, K extends PropertyKey> = Omit<P, Extract<K, keyof P>>;


### PR DESCRIPTION
- Extracted and consolidated common type definitions from Slider, HSL Sliders, and ColorPickers
- Removed onCommit callback from all Slider components for a cleaner, simpler API