### PR TITLE
refactor: destructure props in function parameters for cleaner body

### DIFF
--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -22,17 +22,15 @@ type SliderProps = Expand<
 
 /** ================= Base Slider ================= */
 
-function Slider(props: SliderProps) {
-  const {
-    ['main-thread:writeValue']: externalWriterRef,
-    ['main-thread:onInit']: onInit,
-    ['main-thread:onChange']: onChange,
-    min,
-    rootStyle,
-    trackStyle,
-    ...restProps
-  } = props;
-
+function Slider({
+  ['main-thread:writeValue']: externalWriterRef,
+  ['main-thread:onInit']: onInit,
+  ['main-thread:onChange']: onChange,
+  min,
+  rootStyle,
+  trackStyle,
+  ...restProps
+}: SliderProps) {
   const thumbRef = useMainThreadRef<MainThread.Element | null>(null);
 
   const updateListenerRef = useMainThreadRef<(value: number) => void>();

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -35,18 +35,16 @@ type SliderProps = Expand<
 
 /** ================= Base Slider ================= */
 
-function Slider(props: SliderProps) {
-  const {
-    writeValue: externalWriterRef,
-    ['main-thread:onInit']: onInit,
-    ['main-thread:onChange']: onChange,
-    ['main-thread:writeRootStyle']: writeRootStyle,
-    ['main-thread:writeTrackStyle']: writeTrackStyle,
-    initialRootStyle = {},
-    initialTrackStyle = {},
-    ...restProps
-  } = props;
-
+function Slider({
+  writeValue: externalWriterRef,
+  ['main-thread:onInit']: onInit,
+  ['main-thread:onChange']: onChange,
+  ['main-thread:writeRootStyle']: writeRootStyle,
+  ['main-thread:writeTrackStyle']: writeTrackStyle,
+  initialRootStyle = {},
+  initialTrackStyle = {},
+  ...restProps
+}: SliderProps) {
   const rootRef = useMainThreadRef<MainThread.Element | null>(null);
   const trackRef = useMainThreadRef<MainThread.Element | null>(null);
   const thumbRef = useMainThreadRef<MainThread.Element | null>(null);

--- a/src/components/btc-mts/use-mts-slider.ts
+++ b/src/components/btc-mts/use-mts-slider.ts
@@ -36,18 +36,16 @@ type UseSliderReturnValue = UseSliderReturnValueBase<
   }
 >;
 
-function useSlider(props: UseSliderProps): UseSliderReturnValue {
-  const {
-    writeValue: externalWriterRef,
-    min = 0,
-    max = 100,
-    step: stepProp = 1,
-    initialValue = min,
-    disabled = false,
-    onDerivedChange,
-    onChange,
-  } = props;
-
+function useSlider({
+  writeValue: externalWriterRef,
+  min = 0,
+  max = 100,
+  step: stepProp = 1,
+  initialValue = min,
+  disabled = false,
+  onDerivedChange,
+  onChange,
+}: UseSliderProps): UseSliderReturnValue {
   const step = stepProp > 0 ? stepProp : 1;
   const ratioRef = useMainThreadRef(
     MathUtils.valueToRatio(initialValue, min, max),

--- a/src/components/btc/Slider.tsx
+++ b/src/components/btc/Slider.tsx
@@ -13,9 +13,7 @@ type SliderProps = Expand<
 >;
 
 /** ================= Base Slider ================= */
-function Slider(props: SliderProps) {
-  const { rootStyle, trackStyle, ...sliderProps } = props;
-
+function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
   const {
     handlePointerDown,
     handlePointerMove,

--- a/src/components/btc/use-slider.ts
+++ b/src/components/btc/use-slider.ts
@@ -17,17 +17,15 @@ type UseSliderProps = UseSliderPropsBase<{ value?: number }>;
 type UseSliderReturnValue =
   UseSliderReturnValueBase<UsePointerInteractionReturnValue>;
 
-function useSlider(props: UseSliderProps): UseSliderReturnValue {
-  const {
-    value: controlledValue,
-    min = 0,
-    max = 100,
-    step: stepProp = 1,
-    initialValue = min,
-    disabled = false,
-    onChange,
-  } = props;
-
+function useSlider({
+  value: controlledValue,
+  min = 0,
+  max = 100,
+  step: stepProp = 1,
+  initialValue = min,
+  disabled = false,
+  onChange,
+}: UseSliderProps): UseSliderReturnValue {
   const [value = initialValue, setValue] = useControllable<number>({
     value: controlledValue,
     initialValue,


### PR DESCRIPTION
- All component props are now destructured directly in the function parameter list
- Keeps function bodies cleaner and reduces repetitive prop references
- One exception: a hook (`useMTSControllable`) still references `props.writeValue` inside the body, so destructuring was not applied there