### PR TITLE
refactor(btc-mts): flatten useOwnable API, separate writer vs externalWriter, removed useCallback and useEffect

### DIFF
--- a/src/components/btc-mts/BTCMTSColorPicker.tsx
+++ b/src/components/btc-mts/BTCMTSColorPicker.tsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useCallback,
-  useEffect,
-  runOnBackground,
-} from '@lynx-js/react';
+import { useState, useMemo, runOnBackground } from '@lynx-js/react';
 import { HueSlider, LightnessSlider, SaturationSlider } from './BTCMTSSlider';
 import { HSLGradients } from '@/utils/hsl-gradients';
 import type { Color } from '@/types/color';
@@ -37,24 +31,23 @@ function ColorPicker({
     [hue, saturation],
   );
 
-  const handleHueChange = useCallback((v: number) => {
+  const handleHueChange = (v: number) => {
     'main thread';
     runOnBackground(setHue)(v);
-  }, []);
+    onChange?.([hue, saturation, lightness]);
+  };
 
-  const handleSaturtaionChange = useCallback((v: number) => {
+  const handleSaturtaionChange = (v: number) => {
     'main thread';
     runOnBackground(setSaturation)(v);
-  }, []);
+    onChange?.([hue, saturation, lightness]);
+  };
 
-  const handleLightnessChange = useCallback((v: number) => {
+  const handleLightnessChange = (v: number) => {
     'main thread';
     runOnBackground(setLightness)(v);
-  }, []);
-
-  useEffect(() => {
     onChange?.([hue, saturation, lightness]);
-  }, [hue, saturation, lightness]);
+  };
 
   return (
     <view className="w-full h-full flex flex-col gap-y-4">

--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMainThreadRef } from '@lynx-js/react';
+import { useMainThreadRef } from '@lynx-js/react';
 import type { MainThread, CSSProperties } from '@lynx-js/types';
 import { useSlider } from './use-mts-slider';
 import type { UseSliderProps } from './use-mts-slider';
@@ -35,12 +35,12 @@ function Slider({
 
   const updateListenerRef = useMainThreadRef<(value: number) => void>();
 
-  const handleDerivedChange = useCallback((value: number) => {
+  const handleDerivedChange = (value: number) => {
     'main thread';
     if (updateListenerRef.current) {
       updateListenerRef.current(value);
     }
-  }, []);
+  };
 
   const {
     ratioRef,
@@ -66,7 +66,7 @@ function Slider({
     }
   };
 
-  const initRoot = useCallback((ref: MainThread.Element) => {
+  const initRoot = (ref: MainThread.Element) => {
     'main thread';
     // Bind writeValue to prop
     if (ref) {
@@ -76,9 +76,9 @@ function Slider({
     }
     // Initialization callback
     onInit?.(ref);
-  }, []);
+  };
 
-  const initThumb = useCallback((ref: MainThread.Element) => {
+  const initThumb = (ref: MainThread.Element) => {
     'main thread';
     thumbRef.current = ref;
     if (ref) {
@@ -87,7 +87,7 @@ function Slider({
       updateListenerRef.current = undefined;
     }
     updateThumbStyle();
-  }, []);
+  };
 
   return (
     // Root

--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -44,7 +44,8 @@ function Slider({
 
   const {
     ratioRef,
-    writeValue,
+    initExternalWriter,
+    disposeExternalWriter,
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
@@ -69,9 +70,9 @@ function Slider({
     'main thread';
     // Bind writeValue to prop
     if (ref) {
-      writeValue.init();
+      initExternalWriter();
     } else {
-      writeValue.dispose();
+      disposeExternalWriter();
     }
     // Initialization callback
     onInit?.(ref);

--- a/src/components/btc-mts/MTSColorPicker.tsx
+++ b/src/components/btc-mts/MTSColorPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMainThreadRef } from '@lynx-js/react';
+import { useMainThreadRef } from '@lynx-js/react';
 import { HueSlider, LightnessSlider, SaturationSlider } from './MTSSlider';
 import type { Writer } from './MTSSlider';
 
@@ -21,45 +21,36 @@ function ColorPicker({
   const lightRef = useMainThreadRef(hsl[2]);
   const writeHS = useMainThreadRef<Writer<Vec2>>();
 
-  const writeSliderGradients = useCallback(() => {
+  const writeSliderGradients = () => {
     'main thread';
     writeSL?.current?.([satRef.current, lightRef.current]);
     writeHL?.current?.([hueRef.current, lightRef.current]);
     writeHS?.current?.([hueRef.current, satRef.current]);
-  }, []);
+  };
 
-  const forwardOnHSLChange = useCallback(() => {
+  const forwardOnHSLChange = () => {
     'main thread';
     writeSliderGradients();
     onChange?.([hueRef.current, satRef.current, lightRef.current]);
-  }, [onChange]);
+  };
 
-  const handleHueChange = useCallback(
-    (h: number) => {
-      'main thread';
-      hueRef.current = h;
-      forwardOnHSLChange();
-    },
-    [forwardOnHSLChange],
-  );
+  const handleHueChange = (h: number) => {
+    'main thread';
+    hueRef.current = h;
+    forwardOnHSLChange();
+  };
 
-  const handleSaturationChange = useCallback(
-    (s: number) => {
-      'main thread';
-      satRef.current = s;
-      forwardOnHSLChange();
-    },
-    [forwardOnHSLChange],
-  );
+  const handleSaturationChange = (s: number) => {
+    'main thread';
+    satRef.current = s;
+    forwardOnHSLChange();
+  };
 
-  const handleLightnessChange = useCallback(
-    (l: number) => {
-      ('main thread');
-      lightRef.current = l;
-      forwardOnHSLChange();
-    },
-    [forwardOnHSLChange],
-  );
+  const handleLightnessChange = (l: number) => {
+    ('main thread');
+    lightRef.current = l;
+    forwardOnHSLChange();
+  };
 
   return (
     <view className="w-full h-full flex flex-col gap-y-4">

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMainThreadRef, useState } from '@lynx-js/react';
+import { useMainThreadRef, useState } from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 import { useSlider } from './use-mts-slider';
 import type { UseSliderProps } from './use-mts-slider';
@@ -52,12 +52,12 @@ function Slider({
 
   const updateListenerRef = useMainThreadRef<(value: number) => void>();
 
-  const handleDerivedChange = useCallback((value: number) => {
+  const handleDerivedChange = (value: number) => {
     'main thread';
     if (updateListenerRef.current) {
       updateListenerRef.current(value);
     }
-  }, []);
+  };
 
   const {
     ratioRef,
@@ -105,54 +105,45 @@ function Slider({
     }
   };
 
-  const initRoot = useCallback(
-    (ref: MainThread.Element) => {
-      'main thread';
-      rootRef.current = ref;
-      // Bind writeValue to prop
-      if (ref) {
-        initExternalWriter();
-      } else {
-        disposeExternalWriter();
-      }
-      // Initialization callback
-      onInit?.(ref);
-      if (writeRootStyle) {
-        writeRootStyle.current = updateRootStyle;
-      }
-      // init root style
-      updateRootStyle(rootStyleRef.current);
-    },
-    [updateRootStyle],
-  );
+  const initRoot = (ref: MainThread.Element) => {
+    'main thread';
+    rootRef.current = ref;
+    // Bind writeValue to prop
+    if (ref) {
+      initExternalWriter();
+    } else {
+      disposeExternalWriter();
+    }
+    // Initialization callback
+    onInit?.(ref);
+    if (writeRootStyle) {
+      writeRootStyle.current = updateRootStyle;
+    }
+    // init root style
+    updateRootStyle(rootStyleRef.current);
+  };
 
-  const initTrack = useCallback(
-    (ref: MainThread.Element) => {
-      'main thread';
-      trackRef.current = ref;
+  const initTrack = (ref: MainThread.Element) => {
+    'main thread';
+    trackRef.current = ref;
 
-      if (writeTrackStyle) {
-        writeTrackStyle.current = updateTrackStyle;
-      }
-      // init track style
-      updateTrackStyle(trackStyleRef.current);
-    },
-    [updateTrackStyle],
-  );
+    if (writeTrackStyle) {
+      writeTrackStyle.current = updateTrackStyle;
+    }
+    // init track style
+    updateTrackStyle(trackStyleRef.current);
+  };
 
-  const initThumb = useCallback(
-    (ref: MainThread.Element) => {
-      'main thread';
-      thumbRef.current = ref;
-      if (ref) {
-        updateListenerRef.current = updateThumbStyle;
-      } else {
-        updateListenerRef.current = undefined;
-      }
-      updateThumbStyle();
-    },
-    [updateThumbStyle],
-  );
+  const initThumb = (ref: MainThread.Element) => {
+    'main thread';
+    thumbRef.current = ref;
+    if (ref) {
+      updateListenerRef.current = updateThumbStyle;
+    } else {
+      updateListenerRef.current = undefined;
+    }
+    updateThumbStyle();
+  };
 
   return (
     // Root
@@ -209,12 +200,13 @@ function HueSlider({
       writeTrackStyle.current?.({ 'background-image': trackBg });
     }
   };
-  const init = useCallback(() => {
+
+  const init = () => {
     'main thread';
     if (writeSL) {
       writeSL.current = updateStyle;
     }
-  }, []);
+  };
 
   return (
     <Slider
@@ -258,12 +250,12 @@ function SaturationSlider({
     }
   };
 
-  const init = useCallback(() => {
+  const init = () => {
     'main thread';
     if (writeHL) {
       writeHL.current = updateStyle;
     }
-  }, []);
+  };
 
   return (
     <Slider
@@ -307,12 +299,12 @@ function LightnessSlider({
     }
   };
 
-  const init = useCallback(() => {
+  const init = () => {
     'main thread';
     if (writeHS) {
       writeHS.current = updateStyle;
     }
-  }, []);
+  };
 
   return (
     <Slider

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -3,12 +3,7 @@ import type { MainThread } from '@lynx-js/types';
 import { useSlider } from './use-mts-slider';
 import type { UseSliderProps } from './use-mts-slider';
 
-import type {
-  WriterRef,
-  Writer,
-  WriterWithControlsRef,
-  WriterWithControls,
-} from './use-mts-slider';
+import type { WriterRef, Writer } from './use-mts-slider';
 import type { WriteAction } from './use-mts-ownable';
 import { resolveNextValue } from './use-mts-ownable';
 import { HSLGradients } from '@/utils/hsl-gradients';
@@ -66,7 +61,8 @@ function Slider({
 
   const {
     ratioRef,
-    writeValue,
+    initExternalWriter,
+    disposeExternalWriter,
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
@@ -109,45 +105,54 @@ function Slider({
     }
   };
 
-  const initRoot = useCallback((ref: MainThread.Element) => {
-    'main thread';
-    rootRef.current = ref;
-    // Bind writeValue to prop
-    if (ref) {
-      writeValue.init();
-    } else {
-      writeValue.dispose();
-    }
-    // Initialization callback
-    onInit?.(ref);
-    if (writeRootStyle) {
-      writeRootStyle.current = updateRootStyle;
-    }
-    // init root style
-    updateRootStyle(rootStyleRef.current);
-  }, []);
+  const initRoot = useCallback(
+    (ref: MainThread.Element) => {
+      'main thread';
+      rootRef.current = ref;
+      // Bind writeValue to prop
+      if (ref) {
+        initExternalWriter();
+      } else {
+        disposeExternalWriter();
+      }
+      // Initialization callback
+      onInit?.(ref);
+      if (writeRootStyle) {
+        writeRootStyle.current = updateRootStyle;
+      }
+      // init root style
+      updateRootStyle(rootStyleRef.current);
+    },
+    [updateRootStyle],
+  );
 
-  const initTrack = useCallback((ref: MainThread.Element) => {
-    'main thread';
-    trackRef.current = ref;
+  const initTrack = useCallback(
+    (ref: MainThread.Element) => {
+      'main thread';
+      trackRef.current = ref;
 
-    if (writeTrackStyle) {
-      writeTrackStyle.current = updateTrackStyle;
-    }
-    // init track style
-    updateTrackStyle(trackStyleRef.current);
-  }, []);
+      if (writeTrackStyle) {
+        writeTrackStyle.current = updateTrackStyle;
+      }
+      // init track style
+      updateTrackStyle(trackStyleRef.current);
+    },
+    [updateTrackStyle],
+  );
 
-  const initThumb = useCallback((ref: MainThread.Element) => {
-    'main thread';
-    thumbRef.current = ref;
-    if (ref) {
-      updateListenerRef.current = updateThumbStyle;
-    } else {
-      updateListenerRef.current = undefined;
-    }
-    updateThumbStyle();
-  }, []);
+  const initThumb = useCallback(
+    (ref: MainThread.Element) => {
+      'main thread';
+      thumbRef.current = ref;
+      if (ref) {
+        updateListenerRef.current = updateThumbStyle;
+      } else {
+        updateListenerRef.current = undefined;
+      }
+      updateThumbStyle();
+    },
+    [updateThumbStyle],
+  );
 
   return (
     // Root
@@ -325,7 +330,7 @@ function LightnessSlider({
 }
 
 export { Slider, HueSlider, LightnessSlider, SaturationSlider };
-export type { WriterRef, Writer, WriterWithControls, WriterWithControlsRef };
+export type { WriterRef, Writer };
 
 /** ================= HSL Sliders Shared Types ================= */
 

--- a/src/components/btc-mts/use-mts-ownable.ts
+++ b/src/components/btc-mts/use-mts-ownable.ts
@@ -1,9 +1,4 @@
-import {
-  useCallback,
-  useMemo,
-  useMainThreadRef,
-  MainThreadRef,
-} from '@lynx-js/react';
+import { useMainThreadRef, MainThreadRef } from '@lynx-js/react';
 
 import type { Expand } from '@/types/utils';
 
@@ -12,31 +7,16 @@ type WriteAction<T> = T | ((prev: T) => T);
 type Writer<T> = (next: WriteAction<T>) => void;
 type WriterRef<T> = MainThreadRef<Writer<T> | undefined>;
 
-type WriterWithControls<T> = Writer<T> & {
-  /** Default write: land + derive + notify */
-  write: (next: WriteAction<T>) => void;
-  /** Silent write: land + derive only (no external notify) */
-  writeSilent: (next: WriteAction<T>) => void;
-  /** Notify only: emit external change (no land, no derive) */
-  notify: (next: WriteAction<T>) => void;
-  /** Lifecycle hooks (no-op in owned mode) */
-  init: () => void;
-  dispose: () => void;
+type UseOwnableReturnValue<T> = {
+  valueRef: MainThreadRef<T>;
+  writer: Writer<T>;
+  externalWriter: Writer<T>;
+  initExternalWriter: () => void;
+  disposeExternalWriter: () => void;
 };
-type WriterWithControlsRef<T> = MainThreadRef<
-  WriterWithControls<T> | undefined
->;
-
-type UseOwnableReturnValue<T> = Readonly<
-  [MainThreadRef<T>, WriterWithControls<T>]
->;
-
-type UseOwnedReturnValue<T> = Readonly<
-  [MainThreadRef<T>, WriterWithControls<T>]
->;
 
 interface UseExternalOwnedProps<T> {
-  writeValue: WriterWithControlsRef<T>;
+  writeValue: WriterRef<T>;
   initialValue: T;
   onChange?: (value: T) => void;
   onDerivedChange?: (value: T) => void;
@@ -62,172 +42,73 @@ function useOwnable<T>(props: UseOwnableProps<T>): UseOwnableReturnValue<T> {
   const { initialValue, onChange, onDerivedChange } = props;
 
   // Internal Single Source of Truth
-  const [currentRef, internalWriter] = useOwned({
-    initialValue,
-    onChange,
-    onDerivedChange,
-  });
 
-  const isExternalOwned = isUseExternalOwned(props);
-  const externalWriterRef = isExternalOwned ? props.writeValue : undefined;
-
-  const bindExternal = useCallback(() => {
-    'main thread';
-    if (externalWriterRef) {
-      externalWriterRef.current = internalWriter;
-    }
-  }, [internalWriter]);
-
-  const unbindExternal = useCallback(() => {
-    'main thread';
-    if (!externalWriterRef) return;
-    if (externalWriterRef.current === internalWriter) {
-      externalWriterRef.current = undefined; // Only dispose if set by us (not by external logic)
-    }
-  }, [internalWriter]);
-
-  const write = useCallback(
-    (next: WriteAction<T>) => {
-      'main thread';
-      if (isExternalOwned) {
-        // Default behaviour for external-owned mode: only notify
-        internalWriter.notify(next);
-      } else {
-        internalWriter.write(next);
-      }
-    },
-    [isExternalOwned, internalWriter],
-  );
-
-  const writeSilent = useCallback(
-    (next: WriteAction<T>) => {
-      'main thread';
-      internalWriter.writeSilent(next);
-    },
-    [internalWriter],
-  );
-
-  const notify = useCallback(
-    (next: WriteAction<T>) => {
-      'main thread';
-      internalWriter.notify(next);
-    },
-    [internalWriter],
-  );
-
-  /**
-   * Wrap the internal writer to attach lifecycle:
-   * - default callable = write
-   * - writeSilent / notifyOnly delegated
-   * - init/dispose bind/unbind external writer ref safely
-   */
-
-  const writeCurrent = useMemo<WriterWithControls<T>>(() => {
-    const fn = ((next: WriteAction<T>) => {
-      'main thread';
-      write(next);
-    }) as WriterWithControls<T>;
-    fn.write = write;
-    fn.writeSilent = writeSilent;
-    fn.notify = notify;
-    fn.init = bindExternal;
-    fn.dispose = unbindExternal;
-    return fn;
-  }, [write, writeSilent, notify, bindExternal, unbindExternal]);
-
-  return [currentRef, writeCurrent] as const;
-}
-
-function useOwned<T>({
-  initialValue,
-  onDerivedChange,
-  onChange,
-}: UseOwnedProps<T>): UseOwnedReturnValue<T> {
   const currentRef = useMainThreadRef<T>(initialValue);
 
-  /**
-   * Notify-only path:
-   * - Does NOT land into internal state
-   * - Does NOT trigger derived updates
-   * - ONLY emits external onChange (if changed)
-   */
-  const notify = useCallback<Writer<T>>(
-    (next) => {
-      'main thread';
-      const resolved = resolveNextValue(currentRef.current, next);
-      if (resolved !== undefined && resolved !== currentRef.current) {
-        // External Notify
-        onChange?.(resolved);
-      }
-    },
-    [onChange],
-  );
+  const isExternalOwned = isUseExternalOwned(props);
 
-  /**
-   * Internal commit:
-   * - Resolves next value from current
-   * - Lands into internal state (single source of truth)
-   * - Triggers derived/internal updates
-   * - Optionally emits external onChange
-   */
-  const commit = useCallback(
-    (next: WriteAction<T>, notifyExternal: boolean) => {
-      'main thread';
-      const resolved = resolveNextValue(currentRef.current, next);
-      if (resolved !== undefined && resolved !== currentRef.current) {
+  const externalWriterRef = isExternalOwned ? props.writeValue : undefined;
+
+  const writeCurrentWithOptions = (
+    next: WriteAction<T>,
+    landAndDerive: boolean = true,
+    notifyExternal: boolean = true,
+  ) => {
+    'main thread';
+    const resolved = resolveNextValue(currentRef.current, next);
+    if (resolved !== undefined && resolved !== currentRef.current) {
+      if (landAndDerive) {
         // 1) Land into internal state
         currentRef.current = resolved;
         // 2) Fire derived/internal updates (ratios, layout, animations, etc.)
         onDerivedChange?.(resolved);
-        // 3) Optionally notify external listeners
-        if (notifyExternal) onChange?.(resolved);
       }
-    },
-    [onChange, onDerivedChange, currentRef],
-  );
-  /** Write with external notification (land + derive + notify) */
-  const write = useCallback<Writer<T>>(
-    (n) => {
-      'main thread';
-      commit(n, true);
-    },
-    [commit],
-  );
+      // 3) Optionally notify external listeners
+      if (notifyExternal) onChange?.(resolved);
+    }
+  };
 
-  /** Write silently (land + derive, but NO external notify) */
-  const writeSilent = useCallback<Writer<T>>(
-    (n) => {
-      'main thread';
-      commit(n, false);
-    },
-    [commit],
-  );
-
-  const noop = useCallback(() => {
+  /** Used by Owner */
+  const writer = (next: WriteAction<T>) => {
     'main thread';
-  }, []);
+    if (isExternalOwned) {
+      // Notify
+      // external-owned mode
+      writeCurrentWithOptions(next, false, true);
+    } else {
+      // Land + derive
+      // owned mode
+      writeCurrentWithOptions(next, true, true);
+    }
+  };
 
-  /**
-   * Expose a function-object:
-   * - callable default = write (land + derive + notify)
-   * - writeSilent = land + derive (no notify)
-   * - notifyOnly = emit only (no land, no derive)
-   * - init/dispose = no-op here; meaningful in the higher-level compositors
-   */
-  const writeCurrent = useMemo<WriterWithControls<T>>(() => {
-    const fn = ((next: WriteAction<T>) => {
-      'main thread';
-      write(next);
-    }) as WriterWithControls<T>;
-    fn.write = write;
-    fn.writeSilent = writeSilent;
-    fn.notify = notify;
-    fn.init = noop;
-    fn.dispose = noop;
-    return fn;
-  }, [write, writeSilent, notify]);
+  /** Used by External Owner */
+  const externalWriter = (next: WriteAction<T>) => {
+    'main thread';
+    // Land + Derive, do not notify
+    writeCurrentWithOptions(next, true, false);
+  };
 
-  return [currentRef, writeCurrent] as const;
+  const initExternalWriter = () => {
+    'main thread';
+    if (externalWriterRef) {
+      externalWriterRef.current = externalWriter;
+    }
+  };
+  const disposeExternalWriter = () => {
+    'main thread';
+    if (externalWriterRef) {
+      externalWriterRef.current = undefined;
+    }
+  };
+
+  return {
+    valueRef: currentRef,
+    writer,
+    externalWriter,
+    initExternalWriter,
+    disposeExternalWriter,
+  };
 }
 
 function isUpdater<T>(v: WriteAction<T>): v is (prev: T) => T {
@@ -240,13 +121,12 @@ function resolveNextValue<T>(current: T, next: WriteAction<T>): T {
   return isUpdater(next) ? (next as (p: T) => T)(current) : next;
 }
 
-export { useOwnable, useOwned, resolveNextValue };
+export { useOwnable, resolveNextValue };
 export type {
   UseOwnableProps,
+  UseOwnableReturnValue,
   UseOwnedProps,
   WriteAction,
   Writer,
   WriterRef,
-  WriterWithControls,
-  WriterWithControlsRef,
 };

--- a/src/components/btc-mts/use-mts-slider.ts
+++ b/src/components/btc-mts/use-mts-slider.ts
@@ -10,8 +10,7 @@ import { useOwnable } from './use-mts-ownable';
 import type {
   Writer,
   WriterRef,
-  WriterWithControls,
-  WriterWithControlsRef,
+  UseOwnableReturnValue,
 } from './use-mts-ownable';
 
 import { MTSMathUtils } from '@/utils/mts-math-utils';
@@ -23,21 +22,19 @@ import type {
 } from '@/types/slider';
 
 type UseSliderProps = UseSliderPropsBase<{
-  writeValue?: WriterWithControlsRef<number>;
+  writeValue?: WriterRef<number>;
   onDerivedChange?: (value: number) => void;
 }>;
 
 type UseSliderReturnValue = UseSliderReturnValueBase<
   UsePointerInteractionReturnValue,
-  {
-    writeValue: WriterWithControls<number>;
-    valueRef: MainThreadRef<number>;
+  UseOwnableReturnValue<number> & {
     ratioRef: MainThreadRef<number>;
   }
 >;
 
 function useSlider({
-  writeValue: externalWriterRef,
+  writeValue,
   min = 0,
   max = 100,
   step: stepProp = 1,
@@ -57,8 +54,14 @@ function useSlider({
     onDerivedChange?.(v);
   };
 
-  const [valueRef, writeValue] = useOwnable({
-    writeValue: externalWriterRef,
+  const {
+    valueRef,
+    writer,
+    externalWriter,
+    initExternalWriter,
+    disposeExternalWriter,
+  } = useOwnable({
+    writeValue,
     initialValue,
     onDerivedChange: forwardOnDerivedChange,
     onChange,
@@ -75,7 +78,7 @@ function useSlider({
     const next = quantize(pos);
     // external-owned: only notify change;
     // owned: update internals and notify change;
-    writeValue(next);
+    writer(next);
   };
 
   const pointerReturnedValue = usePointerInteraction({
@@ -83,9 +86,12 @@ function useSlider({
   });
 
   return {
-    valueRef,
-    writeValue,
     ratioRef,
+    valueRef,
+    writer,
+    externalWriter,
+    initExternalWriter,
+    disposeExternalWriter,
     min,
     max,
     step,
@@ -95,11 +101,4 @@ function useSlider({
 }
 
 export { useSlider };
-export type {
-  UseSliderProps,
-  UseSliderReturnValue,
-  WriterRef,
-  Writer,
-  WriterWithControls,
-  WriterWithControlsRef,
-};
+export type { UseSliderProps, UseSliderReturnValue, WriterRef, Writer };

--- a/src/demos/BTCBTCMTSColorPicker.tsx
+++ b/src/demos/BTCBTCMTSColorPicker.tsx
@@ -1,4 +1,4 @@
-import { root, useState } from '@lynx-js/react';
+import { root, runOnBackground, useState } from '@lynx-js/react';
 import { AppLayout } from '@/App';
 import { sleep } from '@/utils/sleep';
 
@@ -14,6 +14,11 @@ if (__BACKGROUND__) {
 export function App() {
   const [value, setValue] = useState<HSL>([199, 99, 72]);
 
+  const handleChange = (next: HSL) => {
+    'main thread';
+    runOnBackground(setValue)(next);
+  };
+
   return (
     <AppLayout
       title="BTC-MTS ColorPicker"
@@ -26,7 +31,7 @@ export function App() {
         <text className="text-content">{`${value}`}</text>
       </view>
       <view className="w-60 h-48">
-        <ColorPicker initialValue={value} main-thread:onChange={setValue} />
+        <ColorPicker initialValue={value} main-thread:onChange={handleChange} />
       </view>
     </AppLayout>
   );

--- a/src/demos/BTCMTSSlider.tsx
+++ b/src/demos/BTCMTSSlider.tsx
@@ -8,7 +8,7 @@ import { AppLayout } from '@/App';
 import { sleep } from '@/utils/sleep';
 
 import { HueSlider } from '@/components/btc-mts/MTSSlider';
-// import type { WriterWithControls } from '@/components/btc-mts/MTSSlider';
+// import type { Writer } from '@/components/btc-mts/MTSSlider';
 
 if (__BACKGROUND__) {
   setInterval(() => {
@@ -20,11 +20,11 @@ export function App() {
   const [value, setValue] = useState(199);
 
   // Uncomment `writeValue` to test BTC owned writer behavior.
-  // const writeValue = useMainThreadRef<WriterWithControls<number>>();
+  // const writeValue = useMainThreadRef<Writer<number>>();
 
   const handleChange = (next: number) => {
     'main thread';
-    //writeValue.current?.(next);
+    // writeValue.current?.(next);
     runOnBackground(setValue)(next);
   };
 


### PR DESCRIPTION
Main Changes: useOwnable API simplify
- Flattened `useOwnable` by removing `useOwned` + `WriterWithControls` indirection.
- Introduced clear separation of responsibilities:
  - `writer`: for self-owned mode (land + derive + notify, or notify-only when external-owned).
  - `externalWriter`: for external ownership (land + derive, no notify).  
- Added explicit lifecycle methods: `initExternalWriter` / `disposeExternalWriter`.
- Unified write paths with `writeCurrentWithOptions`.
- Improved ownership semantics and overall readability.

BTC-MTS Refinements
- Simplified implementation by removing useCallback and useEffect.