### PR TITLE
fix(btc-mts): ensure onChange receives latest HSL values in event callbacks

### DIFF
--- a/src/components/btc-mts/BTCMTSColorPicker.tsx
+++ b/src/components/btc-mts/BTCMTSColorPicker.tsx
@@ -34,19 +34,19 @@ function ColorPicker({
   const handleHueChange = (v: number) => {
     'main thread';
     runOnBackground(setHue)(v);
-    onChange?.([hue, saturation, lightness]);
+    onChange?.([v, saturation, lightness]);
   };
 
   const handleSaturtaionChange = (v: number) => {
     'main thread';
     runOnBackground(setSaturation)(v);
-    onChange?.([hue, saturation, lightness]);
+    onChange?.([hue, v, lightness]);
   };
 
   const handleLightnessChange = (v: number) => {
     'main thread';
     runOnBackground(setLightness)(v);
-    onChange?.([hue, saturation, lightness]);
+    onChange?.([hue, saturation, v]);
   };
 
   return (


### PR DESCRIPTION
Previously, `handleHueChange`, `handleSaturationChange`, and `handleLightnessChange` passed `onChange?.([hue, saturation, lightness])` using possibly stale local state. Since state updates via `setHue`/`setSaturation`/`setLightness` are async, the emitted HSL tuple could lag behind the user's actual interaction.

This PR updates each handler to inject the fresh value directly:
Hue → [v, saturation, lightness]
Saturation → [hue, v, lightness]
Lightness → [hue, saturation, v]

This guarantees `onChange` always receives the latest `HSL` values during interaction.