### PR TITLE
fix(comments): clarify onChange notifications in BTC-MTS useOwnable ownership modes

### DIFF
--- a/src/components/btc-mts/use-mts-ownable.ts
+++ b/src/components/btc-mts/use-mts-ownable.ts
@@ -76,7 +76,7 @@ function useOwnable<T>(props: UseOwnableProps<T>): UseOwnableReturnValue<T> {
       // external-owned mode
       writeCurrentWithOptions(next, false, true);
     } else {
-      // Land + derive
+      // Land + Derive, & Notify
       // owned mode
       writeCurrentWithOptions(next, true, true);
     }
@@ -85,7 +85,8 @@ function useOwnable<T>(props: UseOwnableProps<T>): UseOwnableReturnValue<T> {
   /** Used by External Owner */
   const externalWriter = (next: WriteAction<T>) => {
     'main thread';
-    // Land + Derive, do not notify
+    // Land + Derive (no Notify)
+    // external-owned mode
     writeCurrentWithOptions(next, true, false);
   };
 


### PR DESCRIPTION
- Correct inline comments for useOwnable ownership modes.

- Owned mode: `writeCurrentWithOptions(next, true, true)` → Land + Derive and Notify.

- External-owned mode: `writeCurrentWithOptions(next, false, true)` and `externalWriter(..., true, false)` → Land + Derive, no Notify at externalWriter.

- No runtime logic changes; comments only.