### PR TITLE
feat(mtc): add 3rd MTC ColorPicker demo with a BTC child

### DIFF
--- a/lynx.config.ts
+++ b/lynx.config.ts
@@ -10,6 +10,7 @@ const blockingEnabled = process.env.LYNX_DEMO_BLOCKING_ENABLED === 'true';
 export default defineConfig({
   source: {
     entry: {
+      'MTCColorPicker-BTC': './src/demos/MTCColorPickerBTC.tsx',
       'MTCColorPicker-Signal': './src/demos/MTCColorPicker.tsx',
       'MTCColorPicker-State': './src/demos/MTCColorPickerState.tsx',
       'BTCMTSColorPicker-MTSCoord': './src/demos/BTCMTSColorPicker.tsx',

--- a/src/components/mtc/MTCColorPickerBTC.tsx
+++ b/src/components/mtc/MTCColorPickerBTC.tsx
@@ -1,0 +1,55 @@
+'main thread';
+import { useState } from '@lynx-js/react';
+import type { ReactNode } from '@lynx-js/react';
+import { HueSlider, SaturationSlider, LightnessSlider } from './MTCSliderState';
+
+import type { HSL } from '@/types/color';
+
+interface ColorPickerProps {
+  initialValue: HSL;
+  onChange?: (next: HSL) => void;
+  children?: ReactNode;
+}
+
+function ColorPicker({ initialValue, onChange, children }: ColorPickerProps) {
+  const [h, setH] = useState(initialValue[0]);
+  const [s, setS] = useState(initialValue[1]);
+  const [l, setL] = useState(initialValue[2]);
+
+  return (
+    <view className="w-full h-full flex flex-col gap-y-4">
+      <view className="w-full h-12 flex-row justify-center items-center">
+        {children}
+      </view>
+      <HueSlider
+        s={s}
+        l={l}
+        initialValue={initialValue[0]}
+        onChange={(hue: number) => {
+          setH(hue);
+          onChange?.([hue, s, l]);
+        }}
+      />
+      <SaturationSlider
+        h={h}
+        l={l}
+        initialValue={initialValue[1]}
+        onChange={(sat: number) => {
+          setS(sat);
+          onChange?.([h, sat, l]);
+        }}
+      />
+      <LightnessSlider
+        h={h}
+        s={s}
+        initialValue={initialValue[2]}
+        onChange={(light: number) => {
+          setL(light);
+          onChange?.([h, s, light]);
+        }}
+      />
+    </view>
+  );
+}
+
+export { ColorPicker };

--- a/src/demos/MTCColorPickerBTC.tsx
+++ b/src/demos/MTCColorPickerBTC.tsx
@@ -1,0 +1,44 @@
+import { root, useState } from '@lynx-js/react';
+import { AppLayout } from '@/App';
+import { ColorPicker } from '@/components/mtc/MTCColorPickerBTC';
+import { DummyStyle } from '@/components/ui/DummyStyle';
+import { sleep } from '@/utils/sleep';
+import type { HSL } from '@/types/color';
+
+if (__BACKGROUND__) {
+  setInterval(() => {
+    sleep(250);
+  }, 100);
+}
+
+export function App() {
+  const [value, setValue] = useState<HSL>(() => [199, 99, 72]);
+
+  const handleChange = (v: HSL) => {
+    'background';
+    setValue(v);
+  };
+
+  return (
+    <AppLayout
+      title="MTC-State ColorPicker "
+      subtitle="with a BTC Child"
+      h={value[0]}
+      s={value[1]}
+      l={value[2]}
+    >
+      <DummyStyle />
+      <view className="w-60 h-60">
+        <ColorPicker initialValue={value} onChange={handleChange}>
+          <Tooltip content={`${value}`} />
+        </ColorPicker>
+      </view>
+    </AppLayout>
+  );
+}
+
+function Tooltip({ content }: { content: string }) {
+  return <text className="text-content">{content}</text>;
+}
+
+root.render(<App />);


### PR DESCRIPTION
- Added a new demo for MTC-State ColorPicker embedding a single BTC child.
- Demo setup:

```ts
    <ColorPicker initialValue={value} onChange={handleChange}>
      <Tooltip content={`${value}`} />
    </ColorPicker>
```
- Demonstrates MTC hosting an inner BTC (Tooltip).
- Currently supports only one BTC child — multiple BTC children are not yet handled.