### PR TITLE
feat: add Lynx for Web support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Dist
 node_modules
 dist/
+web/dist/
 
 # IDE
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ From here, you can reproduce our experiments and observe how different patterns 
 
 Press `r` in your terminal to open the entry switcher. Use the up and down `↑`/`↓` arrow keys to navigate between entries, and press `Enter` to load the selected demo.
 
+### Preview in a Browser (Lynx for Web)
+
+You can also preview the demos in a desktop browser via [Lynx for Web](https://lynxjs.org/guide/start/quick-start.html). The web host lives in `web/` and renders each `*.web.bundle` inside a `<lynx-view>` element.
+
+The bundles served by the web host come from the root `dist/` directory (configured as `publicDir` in `web/rsbuild.config.ts`), so you must build them first:
+
+```bash
+# 1. Build Lynx bundles (produces both *.lynx.bundle and *.web.bundle)
+pnpm build
+
+# 2. Start the web host dev server
+pnpm web:dev
+```
+
+For a single-shot production build of both, use `pnpm web:build`.
+
+> Note: `pnpm web:dev` only watches `web/`. To pick up changes in `src/`, re-run `pnpm build` (or run it in a separate terminal in watch mode).
+
 ## Demo Entries
 
 For reference, here is the mapping between the conceptual demo names and the actual entry keys:

--- a/lynx.config.ts
+++ b/lynx.config.ts
@@ -8,6 +8,10 @@ import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
 const blockingEnabled = process.env.LYNX_DEMO_BLOCKING_ENABLED === 'true';
 
 export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
   source: {
     entry: {
       'MTCColorPicker-BTC': './src/demos/MTCColorPickerBTC.tsx',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "build": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy build",
     "dev": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy dev",
     "format": "prettier --write .",
-    "preview": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy preview"
+    "preview": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy preview",
+    "web:dev": "rsbuild dev --config web/rsbuild.config.ts",
+    "web:build": "cross-env LYNX_DEMO_BLOCKING_ENABLED=false rspeedy build && rsbuild build --config web/rsbuild.config.ts"
   },
   "dependencies": {
     "@lynx-js/react": "file:./lynx-js-react-0.112.2.tgz"
@@ -33,10 +35,17 @@
     "@lynx-js/rspeedy": "^0.10.8",
     "@lynx-js/tailwind-preset": "^0.2.0",
     "@lynx-js/types": "3.3.0",
+    "@lynx-js/web-core": "^0.19.8",
+    "@lynx-js/web-elements": "^0.12.0",
+    "@rsbuild/core": "^1.4.15",
+    "@rsbuild/plugin-react": "^1.4.6",
     "@rsbuild/plugin-type-check": "1.2.4",
     "@types/react": "^18.3.23",
+    "@types/react-dom": "^18.3.7",
     "cross-env": "^10.0.0",
     "prettier": "^3.6.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "rsbuild-plugin-tailwindcss": "^0.2.3",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,25 +23,46 @@ importers:
         version: file:lynx-js-react-rsbuild-plugin-0.10.11.tgz(@lynx-js/react@file:lynx-js-react-0.112.2.tgz(@lynx-js/types@3.3.0)(@types/react@18.3.26))(webpack@5.101.3)
       '@lynx-js/rspeedy':
         specifier: ^0.10.8
-        version: 0.10.8(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
+        version: 0.10.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/tailwind-preset':
         specifier: ^0.2.0
         version: 0.2.1(tailwindcss@3.4.18(yaml@2.8.1))
       '@lynx-js/types':
         specifier: 3.3.0
         version: 3.3.0
+      '@lynx-js/web-core':
+        specifier: ^0.19.8
+        version: 0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1))
+      '@lynx-js/web-elements':
+        specifier: ^0.12.0
+        version: 0.12.0(tslib@2.8.1)
+      '@rsbuild/core':
+        specifier: ^1.4.15
+        version: 1.4.15
+      '@rsbuild/plugin-react':
+        specifier: ^1.4.6
+        version: 1.4.6(@rsbuild/core@1.4.15)
       '@rsbuild/plugin-type-check':
         specifier: 1.2.4
-        version: 1.2.4(@rsbuild/core@1.4.15)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.3)
+        version: 1.2.4(@rsbuild/core@1.4.15)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(typescript@5.9.3)
       '@types/react':
         specifier: ^18.3.23
         version: 18.3.26
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.26)
       cross-env:
         specifier: ^10.0.0
         version: 10.1.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       rsbuild-plugin-tailwindcss:
         specifier: ^0.2.3
         version: 0.2.3(@rsbuild/core@1.4.15)(tailwindcss@3.4.18(yaml@2.8.1))
@@ -166,6 +187,12 @@ packages:
   '@lynx-js/css-serializer@0.1.3':
     resolution: {integrity: sha512-AngMqNr8qvGeejv68MjbVNiuYAjzMm3S/t6lrCbtRn8jwa8gVU0Std2mVCMDeIoWzfjjliyRQMd6AzGydOh8dg==}
 
+  '@lynx-js/lynx-core@0.1.3':
+    resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
+
+  '@lynx-js/offscreen-document@0.1.4':
+    resolution: {integrity: sha512-7OUAXZbpWigxOwpcDUU348R9Iw4JZP8qOsNdJ7+Z+LWTWt2DxbkxIKJ/KawQNOp+tsXeOFwUNbrgGkA7aqAX5w==}
+
   '@lynx-js/qrcode-rsbuild-plugin@0.4.3':
     resolution: {integrity: sha512-3WAW4kwNk33UujJjO691TnQyGLL8WrtUVK+p2zzWZOSAUlfhoKZkV6+Seh80II8WJfMlZBAIuT62edQteuew8A==}
     engines: {node: '>=18'}
@@ -247,6 +274,31 @@ packages:
     peerDependencies:
       '@lynx-js/react': '*'
 
+  '@lynx-js/web-constants@0.19.8':
+    resolution: {integrity: sha512-aOk2wmwNu0jJ4ERqU+FBva20uZsQi3Uw1uRwOw8pv3fnetNhW5BlExuGdUzv6XTHbOEd1Jfm4jiOwjrzgXr0PQ==}
+
+  '@lynx-js/web-core@0.19.8':
+    resolution: {integrity: sha512-8J+T7lZYraWcJNEWWLeVWjeUhRaIRPS7XL6l1x5A+5SC8QCNIezUl1fSYIJiRRQLZjph2xXvBn2K5vzQ3PJREw==}
+    peerDependencies:
+      '@lynx-js/lynx-core': 0.1.3
+      '@lynx-js/web-elements': '>0.7.7'
+
+  '@lynx-js/web-elements@0.12.0':
+    resolution: {integrity: sha512-7z8PQQSDMUWrxoizySOg1pKGIiSDeGGomOr5FV0Tx9gniHNJYx0e7/h6wQmwhyHdAZYyihyaBks88QkX8DRNEw==}
+    peerDependencies:
+      tslib: ^2.5.0
+
+  '@lynx-js/web-mainthread-apis@0.19.8':
+    resolution: {integrity: sha512-Ze6u1wg5VZO1htXG6AVRB6CSf1qDcMrxtyl22BMmQhRvm9ut4Ck8k1+e5MIaUCTST1q1j0s59bsKsSstZ/Xlng==}
+
+  '@lynx-js/web-worker-rpc@0.19.8':
+    resolution: {integrity: sha512-POkpPZQjU+a0V/LGWNkaqy+/E6B2WEDYnbh+0FtRNLXcNOBOcgvZNg0fo6VVbw3UInmTwO0v+2g/kMjotizwkg==}
+
+  '@lynx-js/web-worker-runtime@0.19.8':
+    resolution: {integrity: sha512-lZHnEWQ0QrNIHRGUzYBS22d4ckwyUM+1Gee8D2pCYSAdyqr4aRaNJrUEp8sO8YTh91kohN3c09YQcgRZ8sIstQ==}
+    peerDependencies:
+      '@lynx-js/lynx-core': 0.1.3
+
   '@lynx-js/webpack-dev-transport@0.2.0':
     resolution: {integrity: sha512-RSy02FSoMsavEn2wna4khSJwT2uGW4XeLduKH8UDT3aCsBNM/rXndUyG6PbwMcywXCeyb8UofkhaQDtJvNJklA==}
     engines: {node: '>=18'}
@@ -266,20 +318,38 @@ packages:
   '@module-federation/error-codes@0.17.1':
     resolution: {integrity: sha512-n6Elm4qKSjwAPxLUGtwnl7qt4y1dxB8OpSgVvXBIzqI9p27a3ZXshLPLnumlpPg1Qudaj8sLnSnFtt9yGpt5yQ==}
 
+  '@module-federation/error-codes@0.22.0':
+    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
+
   '@module-federation/runtime-core@0.17.1':
     resolution: {integrity: sha512-LCtIFuKgWPQ3E+13OyrVpuTPOWBMI/Ggwsq1Q874YeT8Px28b8tJRCj09DjyRFyhpSPyV/uG80T6iXPAUoLIfQ==}
+
+  '@module-federation/runtime-core@0.22.0':
+    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
 
   '@module-federation/runtime-tools@0.17.1':
     resolution: {integrity: sha512-4kr6zTFFwGywJx6whBtxsc84V+COAuuBpEdEbPZN//YLXhNB0iz2IGsy9r9wDl+06h84bD+3dQ05l9euRLgXzQ==}
 
+  '@module-federation/runtime-tools@0.22.0':
+    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
+
   '@module-federation/runtime@0.17.1':
     resolution: {integrity: sha512-vKEN32MvUbpeuB/s6UXfkHDZ9N5jFyDDJnj83UTJ8n4N1jHIJu9VZ6Yi4/Ac8cfdvU8UIK9bIbfVXWbUYZUDsw==}
+
+  '@module-federation/runtime@0.22.0':
+    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
 
   '@module-federation/sdk@0.17.1':
     resolution: {integrity: sha512-nlUcN6UTEi+3HWF+k8wPy7gH0yUOmCT+xNatihkIVR9REAnr7BUvHFGlPJmx7WEbLPL46+zJUbtQHvLzXwFhng==}
 
+  '@module-federation/sdk@0.22.0':
+    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
+
   '@module-federation/webpack-bundler-runtime@0.17.1':
     resolution: {integrity: sha512-Swspdgf4PzcbvS9SNKFlBzfq8h/Qxwqjq/xRSqw1pqAZWondZQzwTTqPXhgrg0bFlz7qWjBS/6a8KuH/gRvGaQ==}
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -335,6 +405,14 @@ packages:
       '@rsbuild/core':
         optional: true
 
+  '@rsbuild/plugin-react@1.4.6':
+    resolution: {integrity: sha512-LAT6xHlEyZKA0VjF/ph5d50iyG+WSmBx+7g98HNZUwb94VeeTMZFB8qVptTkbIRMss3BNKOXmHOu71Lhsh9oEw==}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
   '@rsbuild/plugin-type-check@1.2.4':
     resolution: {integrity: sha512-0m4TRp9mTgkQ61UWnqE6cOLj/tBltXBWqLYHh8DDz+mk9qabJQ6ilTl8vQbSrg/jYH/3AksQZjlpZMEplUrE2Q==}
     peerDependencies:
@@ -382,8 +460,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.7.9':
+    resolution: {integrity: sha512-64dgstte0If5czi9bA/cpOe0ryY6wC9AIQRtyJ3DlOF6Tt+y9cKkmUoGu3V+WYaYIZRT7HNk8V7kL8amVjFTYw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.4.11':
     resolution: {integrity: sha512-YIV8Wzy+JY0SoSsVtN4wxFXOjzxxVPnVXNswrrfqVUTPr9jqGOFYUWCGpbt8lcCgfuBFm6zN8HpOsKm1xUNsVA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.7.9':
+    resolution: {integrity: sha512-2QSLs3w4rLy4UUGVnIlkt6IlIKOzR1e0RPsq2FYQW6s3p9JrwRCtOeHohyh7EJSqF54dtfhe9UZSAwba3LqH1Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -392,8 +480,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.7.9':
+    resolution: {integrity: sha512-qhUGI/uVfvLmKWts4QkVHGL8yfUyJkblZs+OFD5Upa2y676EOsbQgWsCwX4xGB6Tv+TOzFP0SLh/UfO8ZfdE+w==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.4.11':
     resolution: {integrity: sha512-9evq0DOdxMN/H8VM8ZmyY9NSuBgILNVV6ydBfVPMHPx4r1E7JZGpWeKDegZcS5Erw3sS9kVSIxyX78L5PDzzKw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.7.9':
+    resolution: {integrity: sha512-VjfmR1hgO9n3L6MaE5KG+DXSrrLVqHHOkVcOtS2LMq3bjMTwbBywY7ycymcLnX5KJsol8d3ZGYep6IfSOt3lFA==}
     cpu: [arm64]
     os: [linux]
 
@@ -402,8 +500,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.7.9':
+    resolution: {integrity: sha512-0kldV+3WTs/VYDWzxJ7K40hCW26IHtnk8xPK3whKoo1649rgeXXa0EdsU5P7hG8Ef5SWQjHHHZ/fuHYSO3Y6HA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.4.11':
     resolution: {integrity: sha512-wrm4E7q2k4+cwT6Uhp6hIQ3eUe/YoaUttj6j5TqHYZX6YeLrNPtD9+ne6lQQ17BV8wmm6NZsmoFIJ5xIptpRhQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.7.9':
+    resolution: {integrity: sha512-Gi4872cFtc2d83FKATR6Qcf2VBa/tFCqffI/IwRRl6Hx5FulEBqx+tH7gAuRVF693vrbXNxK+FQ+k4iEsEJxrw==}
     cpu: [x64]
     os: [linux]
 
@@ -411,8 +519,17 @@ packages:
     resolution: {integrity: sha512-hiYxHZjaZ17wQtXyLCK0IdtOvMWreGVTiGsaHCxyeT+SldDG+r16bXNjmlqfZsjlfl1mkAqKz1dg+mMX28OTqw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@1.7.9':
+    resolution: {integrity: sha512-5QEzqo6EaolpuZmK6w/mgSueorgGnnzp7dJaAvBj6ECFIg/aLXhXXmWCWbxt7Ws2gKvG5/PgaxDqbUxYL51juA==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@1.4.11':
     resolution: {integrity: sha512-+HF/mnjmTr8PC1dccRt1bkrD2tPDGeqvXC1BBLYd/Klq1VbtIcnrhfmvQM6KaXbiLcY9VWKzcZPOTmnyZ8TaHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.7.9':
+    resolution: {integrity: sha512-MMqvcrIc8aOqTuHjWkjdzilvoZ3Hv07Od0Foogiyq3JMudsS3Wcmh7T1dFerGg19MOJcRUeEkrg2NQOMOQ6xDA==}
     cpu: [arm64]
     os: [win32]
 
@@ -421,13 +538,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@1.7.9':
+    resolution: {integrity: sha512-4kYYS+NZ2CuNbKjq40yB/UEyB51o1PHj5wpr+Y943oOJXpEKWU2Q4vkF8VEohPEcnA9cKVotYCnqStme+02suA==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.4.11':
     resolution: {integrity: sha512-1Nc5ZzWqfvE+iJc47qtHFzYYnHsC3awavXrCo74GdGip1vxtksM3G30BlvAQHHVtEmULotWqPbjZpflw/Xk9Ag==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.7.9':
+    resolution: {integrity: sha512-1g+QyXXvs+838Un/4GaUvJfARDGHMCs15eXDYWBl5m/Skubyng8djWAgr6ag1+cVoJZXCPOvybTItcblWF3gbQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.4.11':
     resolution: {integrity: sha512-maGl/zRwnl0QVwkBCkgjn5PH20L9HdlRIdkYhEsfTepy5x2QZ0ti/0T49djjTJQrqb+S1i6wWQymMMMMMsxx6Q==}
+
+  '@rspack/binding@1.7.9':
+    resolution: {integrity: sha512-A56e0NdfNwbOSJoilMkxzaPuVYaKCNn1shuiwWnCIBmhV9ix1n9S1XvquDjkGyv+gCdR1+zfJBOa5DMB7htLHw==}
 
   '@rspack/core@1.4.11':
     resolution: {integrity: sha512-JtKnL6p7Kc/YgWQJF3Woo4OccbgKGyT/4187W4dyex8BMkdQcbqCNIdi6dFk02hwQzxpOOxRSBI4hlGRbz7oYQ==}
@@ -438,9 +568,30 @@ packages:
       '@swc/helpers':
         optional: true
 
+  '@rspack/core@1.7.9':
+    resolution: {integrity: sha512-VHuSKvRkuv42Ya+TxEGO0LE0r9+8P4tKGokmomj4R1f/Nu2vtS3yoaIMfC4fR6VuHGd3MZ+KTI0cNNwHfFcskw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
   '@rspack/lite-tapable@1.0.1':
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
     engines: {node: '>=16.0.0'}
+
+  '@rspack/lite-tapable@1.1.0':
+    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
+
+  '@rspack/plugin-react-refresh@1.6.1':
+    resolution: {integrity: sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==}
+    peerDependencies:
+      react-refresh: '>=0.10.0 <1.0.0'
+      webpack-hot-middleware: 2.x
+    peerDependenciesMeta:
+      webpack-hot-middleware:
+        optional: true
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -448,8 +599,8 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
-  '@swc/helpers@0.5.17':
-    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+  '@swc/helpers@0.5.19':
+    resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -499,6 +650,11 @@ packages:
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
 
   '@types/react@18.3.26':
     resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
@@ -1102,6 +1258,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
+
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
     engines: {node: '>= 0.4'}
@@ -1303,6 +1462,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
@@ -1313,6 +1475,9 @@ packages:
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
+
+  hyphenate-style-name@1.1.0:
+    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1521,6 +1686,10 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -1929,6 +2098,19 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
@@ -1992,6 +2174,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
@@ -2077,6 +2262,9 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -2293,6 +2481,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -2491,6 +2682,10 @@ snapshots:
     dependencies:
       css-tree: 3.1.0
 
+  '@lynx-js/lynx-core@0.1.3': {}
+
+  '@lynx-js/offscreen-document@0.1.4': {}
+
   '@lynx-js/qrcode-rsbuild-plugin@0.4.3': {}
 
   '@lynx-js/react-alias-rsbuild-plugin@0.10.11':
@@ -2532,7 +2727,7 @@ snapshots:
     optionalDependencies:
       '@lynx-js/types': 3.3.0
 
-  '@lynx-js/rspeedy@0.10.8(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)':
+  '@lynx-js/rspeedy@0.10.8(@rspack/core@1.7.9(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.101.3)':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.0.1
       '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
@@ -2540,7 +2735,7 @@ snapshots:
       '@lynx-js/websocket': 0.0.4
       '@rsbuild/core': 1.4.15
       '@rsbuild/plugin-css-minimizer': 1.0.3(@rsbuild/core@1.4.15)(webpack@5.101.3)
-      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
+      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2584,6 +2779,40 @@ snapshots:
     dependencies:
       '@lynx-js/react': file:lynx-js-react-0.112.2.tgz(@lynx-js/types@3.3.0)(@types/react@18.3.26)
 
+  '@lynx-js/web-constants@0.19.8':
+    dependencies:
+      '@lynx-js/web-worker-rpc': 0.19.8
+
+  '@lynx-js/web-core@0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1))':
+    dependencies:
+      '@lynx-js/lynx-core': 0.1.3
+      '@lynx-js/offscreen-document': 0.1.4
+      '@lynx-js/web-constants': 0.19.8
+      '@lynx-js/web-elements': 0.12.0(tslib@2.8.1)
+      '@lynx-js/web-mainthread-apis': 0.19.8
+      '@lynx-js/web-worker-rpc': 0.19.8
+      '@lynx-js/web-worker-runtime': 0.19.8(@lynx-js/lynx-core@0.1.3)
+
+  '@lynx-js/web-elements@0.12.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@lynx-js/web-mainthread-apis@0.19.8':
+    dependencies:
+      '@lynx-js/web-constants': 0.19.8
+      hyphenate-style-name: 1.1.0
+      wasm-feature-detect: 1.8.0
+
+  '@lynx-js/web-worker-rpc@0.19.8': {}
+
+  '@lynx-js/web-worker-runtime@0.19.8(@lynx-js/lynx-core@0.1.3)':
+    dependencies:
+      '@lynx-js/lynx-core': 0.1.3
+      '@lynx-js/offscreen-document': 0.1.4
+      '@lynx-js/web-constants': 0.19.8
+      '@lynx-js/web-mainthread-apis': 0.19.8
+      '@lynx-js/web-worker-rpc': 0.19.8
+
   '@lynx-js/webpack-dev-transport@0.2.0': {}
 
   '@lynx-js/webpack-runtime-globals@0.0.5': {}
@@ -2596,15 +2825,30 @@ snapshots:
 
   '@module-federation/error-codes@0.17.1': {}
 
+  '@module-federation/error-codes@0.22.0':
+    optional: true
+
   '@module-federation/runtime-core@0.17.1':
     dependencies:
       '@module-federation/error-codes': 0.17.1
       '@module-federation/sdk': 0.17.1
 
+  '@module-federation/runtime-core@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/sdk': 0.22.0
+    optional: true
+
   '@module-federation/runtime-tools@0.17.1':
     dependencies:
       '@module-federation/runtime': 0.17.1
       '@module-federation/webpack-bundler-runtime': 0.17.1
+
+  '@module-federation/runtime-tools@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/webpack-bundler-runtime': 0.22.0
+    optional: true
 
   '@module-federation/runtime@0.17.1':
     dependencies:
@@ -2612,12 +2856,28 @@ snapshots:
       '@module-federation/runtime-core': 0.17.1
       '@module-federation/sdk': 0.17.1
 
+  '@module-federation/runtime@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/runtime-core': 0.22.0
+      '@module-federation/sdk': 0.22.0
+    optional: true
+
   '@module-federation/sdk@0.17.1': {}
+
+  '@module-federation/sdk@0.22.0':
+    optional: true
 
   '@module-federation/webpack-bundler-runtime@0.17.1':
     dependencies:
       '@module-federation/runtime': 0.17.1
       '@module-federation/sdk': 0.17.1
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/sdk': 0.22.0
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -2659,9 +2919,9 @@ snapshots:
 
   '@rsbuild/core@1.4.15':
     dependencies:
-      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.11(@swc/helpers@0.5.19)
       '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.17
+      '@swc/helpers': 0.5.19
       core-js: 3.45.1
       jiti: 2.6.1
 
@@ -2690,12 +2950,21 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.4.15)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.3)':
+  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@1.4.15)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 1.4.15
+    transitivePeerDependencies:
+      - webpack-hot-middleware
+
+  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.4.15)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.3)
+      ts-checker-rspack-plugin: 1.2.0(@rspack/core@1.7.9(@swc/helpers@0.5.19))(typescript@5.9.3)
     optionalDependencies:
       '@rsbuild/core': 1.4.15
     transitivePeerDependencies:
@@ -2704,13 +2973,13 @@ snapshots:
 
   '@rsdoctor/client@1.2.3': {}
 
-  '@rsdoctor/core@1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)':
+  '@rsdoctor/core@1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.4.15)
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
       axios: 1.13.2
       browserslist-load-config: 1.0.1
       enhanced-resolve: 5.12.0
@@ -2729,10 +2998,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)':
+  '@rsdoctor/graph@1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)':
     dependencies:
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
       lodash.unionby: 4.8.0
       source-map: 0.7.6
     transitivePeerDependencies:
@@ -2740,16 +3009,16 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)':
+  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
+      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.4.15)(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
       lodash: 4.17.21
     optionalDependencies:
-      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
+      '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - bufferutil
@@ -2758,12 +3027,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)':
+  '@rsdoctor/sdk@1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)':
     dependencies:
       '@rsdoctor/client': 1.2.3
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
       '@types/fs-extra': 11.0.4
       body-parser: 1.20.3
       cors: 2.8.5
@@ -2782,20 +3051,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)':
+  '@rsdoctor/types@1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.2.7
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
+      '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
       webpack: 5.101.3
 
-  '@rsdoctor/utils@1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)':
+  '@rsdoctor/utils@1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(webpack@5.101.3)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.9(@swc/helpers@0.5.19))(webpack@5.101.3)
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -2819,19 +3088,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.4.11':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.7.9':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.4.11':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.7.9':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.4.11':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.7.9':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.4.11':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.7.9':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.4.11':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.7.9':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.4.11':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.7.9':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.4.11':
@@ -2839,13 +3126,27 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@rspack/binding-wasm32-wasi@1.7.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.4.11':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.7.9':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.4.11':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.7.9':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.4.11':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.7.9':
     optional: true
 
   '@rspack/binding@1.4.11':
@@ -2861,21 +3162,53 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.4.11
       '@rspack/binding-win32-x64-msvc': 1.4.11
 
-  '@rspack/core@1.4.11(@swc/helpers@0.5.17)':
+  '@rspack/binding@1.7.9':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.7.9
+      '@rspack/binding-darwin-x64': 1.7.9
+      '@rspack/binding-linux-arm64-gnu': 1.7.9
+      '@rspack/binding-linux-arm64-musl': 1.7.9
+      '@rspack/binding-linux-x64-gnu': 1.7.9
+      '@rspack/binding-linux-x64-musl': 1.7.9
+      '@rspack/binding-wasm32-wasi': 1.7.9
+      '@rspack/binding-win32-arm64-msvc': 1.7.9
+      '@rspack/binding-win32-ia32-msvc': 1.7.9
+      '@rspack/binding-win32-x64-msvc': 1.7.9
+    optional: true
+
+  '@rspack/core@1.4.11(@swc/helpers@0.5.19)':
     dependencies:
       '@module-federation/runtime-tools': 0.17.1
       '@rspack/binding': 1.4.11
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
-      '@swc/helpers': 0.5.17
+      '@swc/helpers': 0.5.19
+
+  '@rspack/core@1.7.9(@swc/helpers@0.5.19)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.22.0
+      '@rspack/binding': 1.7.9
+      '@rspack/lite-tapable': 1.1.0
+    optionalDependencies:
+      '@swc/helpers': 0.5.19
+    optional: true
 
   '@rspack/lite-tapable@1.0.1': {}
+
+  '@rspack/lite-tapable@1.1.0':
+    optional: true
+
+  '@rspack/plugin-react-refresh@1.6.1(react-refresh@0.18.0)':
+    dependencies:
+      error-stack-parser: 2.1.4
+      html-entities: 2.6.0
+      react-refresh: 0.18.0
 
   '@sinclair/typebox@0.27.8': {}
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@swc/helpers@0.5.17':
+  '@swc/helpers@0.5.19':
     dependencies:
       tslib: 2.8.1
 
@@ -2934,6 +3267,10 @@ snapshots:
       undici-types: 7.16.0
 
   '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.26)':
+    dependencies:
+      '@types/react': 18.3.26
 
   '@types/react@18.3.26':
     dependencies:
@@ -3546,6 +3883,10 @@ snapshots:
 
   envinfo@7.14.0: {}
 
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
+
   es-abstract@1.24.0:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -3804,6 +4145,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-entities@2.6.0: {}
+
   htmlparser2@10.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -3820,6 +4163,8 @@ snapshots:
       toidentifier: 1.0.1
 
   hyperdyperid@1.2.0: {}
+
+  hyphenate-style-name@1.1.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -4022,6 +4367,10 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.21: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
 
@@ -4373,6 +4722,18 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.18.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
@@ -4447,6 +4808,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   schema-utils@4.3.3:
     dependencies:
@@ -4567,6 +4932,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
+
+  stackframe@1.3.4: {}
 
   statuses@1.5.0: {}
 
@@ -4730,7 +5097,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-checker-rspack-plugin@1.2.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.3):
+  ts-checker-rspack-plugin@1.2.0(@rspack/core@1.7.9(@swc/helpers@0.5.19))(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.0.1
@@ -4741,7 +5108,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.3
     optionalDependencies:
-      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
+      '@rspack/core': 1.7.9(@swc/helpers@0.5.19)
 
   ts-interface-checker@0.1.13: {}
 
@@ -4837,6 +5204,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
+
+  wasm-feature-detect@1.8.0: {}
 
   watchpack@2.4.4:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export function AppLayout({
       {/* ColorDisplay */}
       <MaskIcon
         iconUrl={logoUrl}
-        className="absolute bottom-1/3 rounded-full size-72 bg-content"
+        className="absolute bottom-1/3 left-1/2 -translate-x-1/2 rounded-full size-72 bg-content"
         style={color ? { backgroundColor: color } : undefined}
       />
       {/* BottomSheet */}

--- a/src/components/btc-mts/BTCMTSSlider.tsx
+++ b/src/components/btc-mts/BTCMTSSlider.tsx
@@ -49,6 +49,10 @@ function Slider({
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
     handleElementLayoutChange,
   } = useSlider({
     writeValue: externalWriterRef,
@@ -97,6 +101,10 @@ function Slider({
       main-thread:bindtouchmove={handlePointerMove}
       main-thread:bindtouchend={handlePointerUp}
       main-thread:bindtouchcancel={handlePointerUp}
+      main-thread:bindmousedown={handleMouseDown}
+      main-thread:bindmousemove={handleMouseMove}
+      main-thread:bindmouseup={handleMouseUp}
+      main-thread:global-bindmouseup={handleMouseCancel}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
       style={rootStyle}
     >

--- a/src/components/btc-mts/MTSSlider.tsx
+++ b/src/components/btc-mts/MTSSlider.tsx
@@ -66,6 +66,10 @@ function Slider({
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
     handleElementLayoutChange,
   } = useSlider({
     writeValue: externalWriterRef,
@@ -153,6 +157,10 @@ function Slider({
       main-thread:bindtouchmove={handlePointerMove}
       main-thread:bindtouchend={handlePointerUp}
       main-thread:bindtouchcancel={handlePointerUp}
+      main-thread:bindmousedown={handleMouseDown}
+      main-thread:bindmousemove={handleMouseMove}
+      main-thread:bindmouseup={handleMouseUp}
+      main-thread:global-bindmouseup={handleMouseCancel}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
     >
       {/* Track Positioner */}

--- a/src/components/btc-mts/use-mts-pointer-interaction.ts
+++ b/src/components/btc-mts/use-mts-pointer-interaction.ts
@@ -93,6 +93,9 @@ function usePointerInteraction({
 
   const handlePointerDown = (e: MainThread.TouchEvent) => {
     'main thread';
+    // Clear the prior gesture's snapshot so a fallback commit from this
+    // gesture can never re-emit the previous gesture's position.
+    posRef.current = null;
     draggingRef.current = true;
     const x = pickCoord(e);
     if (x === null) return;
@@ -123,6 +126,7 @@ function usePointerInteraction({
 
   const handleMouseDown = (e: MainThread.MouseEvent) => {
     'main thread';
+    posRef.current = null;
     draggingRef.current = true;
     const x = e.clientX ?? e.pageX;
     updateFromX(x);
@@ -166,8 +170,12 @@ function usePointerInteraction({
   ) => {
     'main thread';
     elementWidthRef.current = e.detail.width;
-    const rect: { left: number } =
-      await e.currentTarget.invoke('boundingClientRect');
+    // Screen-relative on native, viewport-relative on Lynx Web — matches
+    // the coord source (`detail.x` / `clientX`) on each platform.
+    const rect: { left: number } = await e.currentTarget.invoke(
+      'boundingClientRect',
+      { relativeTo: 'screen' },
+    );
     elementLeftRef.current = rect.left;
   };
 

--- a/src/components/btc-mts/use-mts-pointer-interaction.ts
+++ b/src/components/btc-mts/use-mts-pointer-interaction.ts
@@ -16,6 +16,11 @@ import type {
  * Notes:
  * - We rely on `handleElementLayoutChange` to keep `left/width` fresh.
  * - If element metrics are not ready when a pointer event arrives, we skip updates safely.
+ *
+ * Web/native unified coords:
+ * - Touch on Lynx Web: `touches[0].clientX` is populated.
+ * - Touch on native: falls back to `e.detail.x`.
+ * - Desktop web has no touch events; `bindmouse{down,move,up}` handlers cover it.
  */
 
 function usePointerInteraction({
@@ -31,8 +36,29 @@ function usePointerInteraction({
 
   const draggingRef = useMainThreadRef(false);
 
-  const buildPosition = (x: number): PointerPosition | null => {
+  const isWebPlatformRef = useMainThreadRef<boolean>(
+    (SystemInfo.platform as string) === 'web',
+  );
+
+  /**
+   * Extract the X coordinate from a touch event.
+   * Prefers `clientX` (Lynx Web populates it), falls back to Lynx `detail.x`.
+   */
+  const pickCoord = (e: MainThread.TouchEvent): number | null => {
     'main thread';
+    if (!isWebPlatformRef.current) {
+      return e.detail?.x ?? null;
+    }
+
+    const t = e.touches?.[0] ?? e.changedTouches?.[0];
+    const cx = (t as unknown as { clientX?: number } | undefined)?.clientX;
+    if (cx != null) return cx;
+    return e.detail?.x ?? null;
+  };
+
+  const buildPosition = (x: number | null): PointerPosition | null => {
+    'main thread';
+    if (x === null) return null;
     const elementWidth = elementWidthRef.current;
     const elementLeft = elementLeftRef.current;
 
@@ -46,34 +72,98 @@ function usePointerInteraction({
     return null;
   };
 
-  const handlePointerDown = (e: MainThread.TouchEvent) => {
+  const updateFromX = (x: number) => {
     'main thread';
-    draggingRef.current = true;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
+    const pos = buildPosition(x);
+    if (pos) {
+      onUpdate?.(pos);
     }
   };
 
-  const handlePointerMove = (e: MainThread.TouchEvent) => {
+  const commitCurrentPosition = () => {
     'main thread';
     if (!draggingRef.current) return;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
-    }
-  };
-
-  const handlePointerUp = (e: MainThread.TouchEvent) => {
-    'main thread';
     draggingRef.current = false;
-    buildPosition(e.detail.x);
     if (posRef.current) {
       onCommit?.(posRef.current);
     }
   };
 
-  const handleElementLayoutChange = async (e: MainThread.LayoutChangeEvent) => {
+  // ── Touch handlers (native + web touch devices) ──
+
+  const handlePointerDown = (e: MainThread.TouchEvent) => {
+    'main thread';
+    draggingRef.current = true;
+    const x = pickCoord(e);
+    if (x === null) return;
+    updateFromX(x);
+  };
+
+  const handlePointerMove = (e: MainThread.TouchEvent) => {
+    'main thread';
+    if (!draggingRef.current) return;
+    const x = pickCoord(e);
+    if (x === null) return;
+    updateFromX(x);
+  };
+
+  const handlePointerUp = (e: MainThread.TouchEvent) => {
+    'main thread';
+    draggingRef.current = false;
+    const x = pickCoord(e);
+    const pos = x === null ? null : buildPosition(x);
+    if (pos) {
+      onCommit?.(pos);
+    } else if (posRef.current) {
+      onCommit?.(posRef.current);
+    }
+  };
+
+  // ── Mouse handlers (desktop web where touch events are unavailable) ──
+
+  const handleMouseDown = (e: MainThread.MouseEvent) => {
+    'main thread';
+    draggingRef.current = true;
+    const x = e.clientX ?? e.pageX;
+    updateFromX(x);
+  };
+
+  const handleMouseMove = (e: MainThread.MouseEvent) => {
+    'main thread';
+    if (!draggingRef.current) return;
+    // Self-heal: if the user released the button outside the slider, the
+    // local `mouseup` never fires. Detect via `buttons` and finalize here so
+    // `draggingRef` doesn't stay stuck across unrelated future interactions.
+    if (e.buttons != null && (e.buttons & 1) === 0) {
+      commitCurrentPosition();
+      return;
+    }
+    const x = e.clientX ?? e.pageX;
+    updateFromX(x);
+  };
+
+  const handleMouseUp = (e: MainThread.MouseEvent) => {
+    'main thread';
+    const wasDragging = draggingRef.current;
+    draggingRef.current = false;
+    if (!wasDragging) return;
+    const x = e.clientX ?? e.pageX;
+    const pos = buildPosition(x);
+    if (pos) {
+      onCommit?.(pos);
+    } else if (posRef.current) {
+      onCommit?.(posRef.current);
+    }
+  };
+
+  const handleMouseCancel = () => {
+    'main thread';
+    commitCurrentPosition();
+  };
+
+  const handleElementLayoutChange = async (
+    e: MainThread.LayoutChangeEvent,
+  ) => {
     'main thread';
     elementWidthRef.current = e.detail.width;
     const rect: { left: number } =
@@ -85,13 +175,18 @@ function usePointerInteraction({
     handlePointerDown: handlePointerDown,
     handlePointerMove: handlePointerMove,
     handlePointerUp: handlePointerUp,
+    handleMouseDown: handleMouseDown,
+    handleMouseMove: handleMouseMove,
+    handleMouseUp: handleMouseUp,
+    handleMouseCancel: handleMouseCancel,
     handleElementLayoutChange: handleElementLayoutChange,
   };
 }
 
 type UsePointerInteractionReturnValue = UsePointerInteractionReturnValueBase<
   MainThread.TouchEvent,
-  MainThread.LayoutChangeEvent
+  MainThread.LayoutChangeEvent,
+  MainThread.MouseEvent
 >;
 
 export { usePointerInteraction };

--- a/src/components/btc/Slider.tsx
+++ b/src/components/btc/Slider.tsx
@@ -18,6 +18,10 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
     handleElementLayoutChange,
     ratio,
   } = useSlider(sliderProps);
@@ -29,6 +33,10 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
       bindtouchmove={handlePointerMove}
       bindtouchend={handlePointerUp}
       bindtouchcancel={handlePointerUp}
+      bindmousedown={handleMouseDown}
+      bindmousemove={handleMouseMove}
+      bindmouseup={handleMouseUp}
+      global-bindmouseup={handleMouseCancel}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
       style={rootStyle}
     >

--- a/src/components/btc/use-pointer-interaction.ts
+++ b/src/components/btc/use-pointer-interaction.ts
@@ -137,6 +137,9 @@ function usePointerInteraction({
   // ── Touch handlers (native + web touch devices) ──
 
   const handlePointerDown = (e: TouchEvent) => {
+    // Clear the prior gesture's snapshot so a fallback commit from this
+    // gesture can never re-emit the previous gesture's position.
+    posRef.current = null;
     draggingRef.current = true;
     const x = pickCoord(e);
     if (x === null) return;
@@ -169,6 +172,7 @@ function usePointerInteraction({
   // ── Mouse handlers (desktop web where touch events are unavailable) ──
 
   const handleMouseDown = (e: MouseEvent) => {
+    posRef.current = null;
     draggingRef.current = true;
     const x = e.clientX ?? e.pageX;
     updateFromFreshRect(x);

--- a/src/components/btc/use-pointer-interaction.ts
+++ b/src/components/btc/use-pointer-interaction.ts
@@ -1,5 +1,5 @@
 import { useRef } from '@lynx-js/react';
-import type { LayoutChangeEvent, TouchEvent } from '@lynx-js/types';
+import type { LayoutChangeEvent, TouchEvent, MouseEvent } from '@lynx-js/types';
 import type {
   PointerPosition,
   UsePointerInteractionProps,
@@ -15,6 +15,14 @@ import type {
  *   itself (container === element).
  *
  * No clamping/step logic is applied here.
+ *
+ * Web/native unified coords:
+ * - Touch on Lynx Web: `touches[0].clientX` is populated.
+ * - Touch on native: falls back to `e.detail.x`.
+ * - Desktop web has no touch events; `bindmouse{down,move,up}` handlers cover it.
+ * - `boundingClientRect` keeps `relativeTo: 'screen'`, which Lynx maps to
+ *   the viewport on web and to the screen on native — matching the coord
+ *   source on each platform.
  */
 function usePointerInteraction({
   onUpdate,
@@ -29,7 +37,67 @@ function usePointerInteraction({
 
   const draggingRef = useRef(false);
 
-  const buildPosition = (x: number): PointerPosition | null => {
+  const isWebPlatformRef = useRef<boolean>(
+    (SystemInfo.platform as string) === 'web',
+  );
+
+  /** Keep the last known element id so we can re-query rect on demand (web compat). */
+  const targetIdRef = useRef<number | string | null>(null);
+
+  /**
+   * Extract the X coordinate from a touch event.
+   * Prefers `clientX` (Lynx Web populates it), falls back to Lynx `detail.x`.
+   */
+  const pickCoord = (e: TouchEvent): number | null => {
+    if (!isWebPlatformRef.current) {
+      return e.detail?.x ?? null;
+    }
+
+    const t = e.touches?.[0] ?? e.changedTouches?.[0];
+    const cx = (t as unknown as { clientX?: number } | undefined)?.clientX;
+    if (cx != null) return cx;
+    return e.detail?.x ?? null;
+  };
+
+  const queryRectById = (
+    id: number | string | null,
+    onSuccess?: () => void,
+    onFail?: () => void,
+  ) => {
+    if (id == null) {
+      onFail?.();
+      return;
+    }
+
+    const query = lynx.createSelectorQuery();
+    // @ts-expect-error Lynx internal UniqueID typing
+    const currentTarget = query.selectUniqueID(id);
+
+    if (!currentTarget) {
+      onFail?.();
+      return;
+    }
+
+    currentTarget
+      .invoke({
+        method: 'boundingClientRect',
+        // Screen-relative on native, viewport-relative on Lynx Web — matches
+        // the coord source (`detail.x` / `clientX`) on each platform.
+        params: { relativeTo: 'screen' },
+        success: (res: { left: number; width?: number }) => {
+          eleLeftRef.current = res.left;
+          if (Number.isFinite(res.width) && (res.width ?? 0) > 0) {
+            eleWidthRef.current = res.width ?? eleWidthRef.current;
+          }
+          onSuccess?.();
+        },
+        fail: onFail,
+      })
+      .exec();
+  };
+
+  const buildPosition = (x: number | null): PointerPosition | null => {
+    if (x === null) return null;
     const width = eleWidthRef.current;
     const left = eleLeftRef.current;
 
@@ -43,61 +111,126 @@ function usePointerInteraction({
     return null;
   };
 
+  const updateFromX = (x: number) => {
+    const pos = buildPosition(x);
+    if (pos) onUpdate?.(pos);
+  };
+
+  const updateFromFreshRect = (x: number) => {
+    queryRectById(
+      targetIdRef.current,
+      () => {
+        if (draggingRef.current) updateFromX(x);
+      },
+      () => {
+        if (draggingRef.current) updateFromX(x);
+      },
+    );
+  };
+
+  const commitCurrentPosition = () => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    if (posRef.current) onCommit?.(posRef.current);
+  };
+
+  // ── Touch handlers (native + web touch devices) ──
+
   const handlePointerDown = (e: TouchEvent) => {
     draggingRef.current = true;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
-    }
+    const x = pickCoord(e);
+    if (x === null) return;
+    updateFromFreshRect(x);
   };
 
   const handlePointerMove = (e: TouchEvent) => {
     if (!draggingRef.current) return;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
-    }
+    const x = pickCoord(e);
+    if (x === null) return;
+    updateFromX(x);
   };
 
   const handlePointerUp = (e: TouchEvent) => {
     draggingRef.current = false;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
+    const x = pickCoord(e);
+    if (x === null) {
+      if (posRef.current) onCommit?.(posRef.current);
+      return;
+    }
+    const pos = buildPosition(x);
+    if (pos) {
+      onUpdate?.(pos);
+      onCommit?.(pos);
+    } else if (posRef.current) {
       onCommit?.(posRef.current);
     }
+  };
+
+  // ── Mouse handlers (desktop web where touch events are unavailable) ──
+
+  const handleMouseDown = (e: MouseEvent) => {
+    draggingRef.current = true;
+    const x = e.clientX ?? e.pageX;
+    updateFromFreshRect(x);
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!draggingRef.current) return;
+    // Self-heal: if the user released the button outside the slider, the
+    // local `mouseup` never fires. Detect via `buttons` and finalize here so
+    // `draggingRef` doesn't stay stuck across unrelated future interactions.
+    if (e.buttons != null && (e.buttons & 1) === 0) {
+      commitCurrentPosition();
+      return;
+    }
+    const x = e.clientX ?? e.pageX;
+    updateFromX(x);
+  };
+
+  const handleMouseUp = (e: MouseEvent) => {
+    const wasDragging = draggingRef.current;
+    draggingRef.current = false;
+    if (!wasDragging) return;
+    const x = e.clientX ?? e.pageX;
+    const pos = buildPosition(x);
+    if (pos) {
+      onUpdate?.(pos);
+      onCommit?.(pos);
+    } else if (posRef.current) {
+      onCommit?.(posRef.current);
+    }
+  };
+
+  const handleMouseCancel = () => {
+    commitCurrentPosition();
   };
 
   const handleElementLayoutChange = (e: LayoutChangeEvent) => {
     eleWidthRef.current = e.detail.width;
 
-    const currentTarget = lynx
-      .createSelectorQuery()
-      // @ts-expect-error
-      .selectUniqueID(e.currentTarget.uid);
+    // @ts-expect-error Lynx internal UniqueID typing
+    const id = e.currentTarget.uid ?? e.currentTarget.uniqueId;
+    targetIdRef.current = id;
 
-    currentTarget
-      ?.invoke({
-        method: 'boundingClientRect',
-        params: { relativeTo: 'screen' }, // screen-based so it matches e.detail.x
-        success: (res: { left: number }) => {
-          eleLeftRef.current = res.left;
-        },
-      })
-      .exec();
+    queryRectById(id);
   };
 
   return {
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
     handleElementLayoutChange,
   };
 }
 
 type UsePointerInteractionReturnValue = UsePointerInteractionReturnValueBase<
   TouchEvent,
-  LayoutChangeEvent
+  LayoutChangeEvent,
+  MouseEvent
 >;
 
 export { usePointerInteraction };

--- a/src/components/mtc/MTCSliderSignal.tsx
+++ b/src/components/mtc/MTCSliderSignal.tsx
@@ -31,6 +31,10 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
   } = useSlider(sliderProps);
 
   return (
@@ -44,6 +48,13 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
       bindtouchend={handlePointerUp}
       // @ts-expect-error
       bindtouchcancel={handlePointerUp}
+      // @ts-expect-error MTC type mismatch
+      bindmousedown={handleMouseDown}
+      // @ts-expect-error MTC type mismatch
+      bindmousemove={handleMouseMove}
+      // @ts-expect-error MTC type mismatch
+      bindmouseup={handleMouseUp}
+      global-bindmouseup={handleMouseCancel}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
       style={rootStyle}
     >

--- a/src/components/mtc/MTCSliderState.tsx
+++ b/src/components/mtc/MTCSliderState.tsx
@@ -28,6 +28,10 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
   } = useSlider(sliderProps);
 
   return (
@@ -43,6 +47,13 @@ function Slider({ rootStyle, trackStyle, ...sliderProps }: SliderProps) {
       bindtouchend={handlePointerUp}
       // @ts-expect-error
       bindtouchcancel={handlePointerUp}
+      // @ts-expect-error MTC type mismatch
+      bindmousedown={handleMouseDown}
+      // @ts-expect-error MTC type mismatch
+      bindmousemove={handleMouseMove}
+      // @ts-expect-error MTC type mismatch
+      bindmouseup={handleMouseUp}
+      global-bindmouseup={handleMouseCancel}
       className="relative px-5 bg-primary w-full h-10 flex flex-row items-center rounded-full"
       style={rootStyle}
     >

--- a/src/components/mtc/use-mtc-pointer-interaction.ts
+++ b/src/components/mtc/use-mtc-pointer-interaction.ts
@@ -15,6 +15,11 @@ import type {
  * - If no separate container is needed, bind handlers on the element itself.
  *
  * No clamping/step logic is applied here.
+ *
+ * Web/native unified coords:
+ * - Touch on Lynx Web: `touches[0].clientX` is populated.
+ * - Touch on native: falls back to `e.detail.x`.
+ * - Desktop web has no touch events; `bindmouse{down,move,up}` handlers cover it.
  */
 function usePointerInteraction({
   onUpdate,
@@ -29,7 +34,27 @@ function usePointerInteraction({
 
   const draggingRef = useRef(false);
 
-  function buildPosition(x: number): PointerPosition | null {
+  const isWebPlatformRef = useRef<boolean>(
+    (SystemInfo.platform as string) === 'web',
+  );
+
+  /**
+   * Extract the X coordinate from a touch event.
+   * Prefers `clientX` (Lynx Web populates it), falls back to Lynx `detail.x`.
+   */
+  function pickCoord(e: MainThread.TouchEvent): number | null {
+    if (!isWebPlatformRef.current) {
+      return e.detail?.x ?? null;
+    }
+
+    const t = e.touches?.[0] ?? e.changedTouches?.[0];
+    const cx = (t as unknown as { clientX?: number } | undefined)?.clientX;
+    if (cx != null) return cx;
+    return e.detail?.x ?? null;
+  }
+
+  function buildPosition(x: number | null): PointerPosition | null {
+    if (x === null) return null;
     const width = eleWidthRef.current;
     const left = eleLeftRef.current;
 
@@ -43,30 +68,86 @@ function usePointerInteraction({
     return null;
   }
 
+  function updateFromX(x: number) {
+    const pos = buildPosition(x);
+    if (pos) {
+      onUpdate?.(pos);
+    }
+  }
+
+  function commitCurrentPosition() {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    if (posRef.current) {
+      onCommit?.(posRef.current);
+    }
+  }
+
+  // ── Touch handlers (native + web touch devices) ──
+
   function handlePointerDown(e: MainThread.TouchEvent) {
     draggingRef.current = true;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
-    }
+    const x = pickCoord(e);
+    if (x === null) return;
+    updateFromX(x);
   }
 
   function handlePointerMove(e: MainThread.TouchEvent) {
     if (!draggingRef.current) return;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      onUpdate?.(posRef.current);
-    }
+    const x = pickCoord(e);
+    if (x === null) return;
+    updateFromX(x);
   }
 
   function handlePointerUp(e: MainThread.TouchEvent) {
     draggingRef.current = false;
-    buildPosition(e.detail.x);
-    if (posRef.current) {
-      // Fire update then commit on release.
-      onUpdate?.(posRef.current);
+    const x = pickCoord(e);
+    const pos = x === null ? null : buildPosition(x);
+    if (pos) {
+      onUpdate?.(pos);
+      onCommit?.(pos);
+    } else if (posRef.current) {
       onCommit?.(posRef.current);
     }
+  }
+
+  // ── Mouse handlers (desktop web where touch events are unavailable) ──
+
+  function handleMouseDown(e: MainThread.MouseEvent) {
+    draggingRef.current = true;
+    const x = e.clientX ?? e.pageX;
+    updateFromX(x);
+  }
+
+  function handleMouseMove(e: MainThread.MouseEvent) {
+    if (!draggingRef.current) return;
+    // Self-heal: if the user released the button outside the slider, the
+    // local `mouseup` never fires. Detect via `buttons` and finalize here so
+    // `draggingRef` doesn't stay stuck across unrelated future interactions.
+    if (e.buttons != null && (e.buttons & 1) === 0) {
+      commitCurrentPosition();
+      return;
+    }
+    const x = e.clientX ?? e.pageX;
+    updateFromX(x);
+  }
+
+  function handleMouseUp(e: MainThread.MouseEvent) {
+    const wasDragging = draggingRef.current;
+    draggingRef.current = false;
+    if (!wasDragging) return;
+    const x = e.clientX ?? e.pageX;
+    const pos = buildPosition(x);
+    if (pos) {
+      onUpdate?.(pos);
+      onCommit?.(pos);
+    } else if (posRef.current) {
+      onCommit?.(posRef.current);
+    }
+  }
+
+  function handleMouseCancel() {
+    commitCurrentPosition();
   }
 
   function handleElementLayoutChange(e: MainThread.LayoutChangeEvent) {
@@ -75,24 +156,29 @@ function usePointerInteraction({
     e.currentTarget
       .invoke('boundingClientRect')
       .then((rect: { left: number }) => {
-        // Screen-based rect so it aligns with e.detail.x
         eleLeftRef.current = rect.left;
       })
       .catch((err) => {
         console.error('Failed to get boundingClientRect:', err);
       });
   }
+
   return {
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseCancel,
     handleElementLayoutChange,
   };
 }
 
 type UsePointerInteractionReturnValue = UsePointerInteractionReturnValueBase<
   MainThread.TouchEvent,
-  MainThread.LayoutChangeEvent
+  MainThread.LayoutChangeEvent,
+  MainThread.MouseEvent
 >;
 
 export { usePointerInteraction };

--- a/src/components/mtc/use-mtc-pointer-interaction.ts
+++ b/src/components/mtc/use-mtc-pointer-interaction.ts
@@ -86,6 +86,9 @@ function usePointerInteraction({
   // ── Touch handlers (native + web touch devices) ──
 
   function handlePointerDown(e: MainThread.TouchEvent) {
+    // Clear the prior gesture's snapshot so a fallback commit from this
+    // gesture can never re-emit the previous gesture's position.
+    posRef.current = null;
     draggingRef.current = true;
     const x = pickCoord(e);
     if (x === null) return;
@@ -114,6 +117,7 @@ function usePointerInteraction({
   // ── Mouse handlers (desktop web where touch events are unavailable) ──
 
   function handleMouseDown(e: MainThread.MouseEvent) {
+    posRef.current = null;
     draggingRef.current = true;
     const x = e.clientX ?? e.pageX;
     updateFromX(x);
@@ -153,8 +157,10 @@ function usePointerInteraction({
   function handleElementLayoutChange(e: MainThread.LayoutChangeEvent) {
     eleWidthRef.current = e.detail.width;
 
+    // Screen-relative on native, viewport-relative on Lynx Web — matches
+    // the coord source (`detail.x` / `clientX`) on each platform.
     e.currentTarget
-      .invoke('boundingClientRect')
+      .invoke('boundingClientRect', { relativeTo: 'screen' })
       .then((rect: { left: number }) => {
         eleLeftRef.current = rect.left;
       })

--- a/src/types/pointer.ts
+++ b/src/types/pointer.ts
@@ -16,7 +16,7 @@ interface UsePointerInteractionProps {
   onCommit?: (pos: PointerPosition) => void;
 }
 
-type UsePointerInteractionReturnValueBase<TTouch, TLayout> = {
+type UsePointerInteractionReturnValueBase<TTouch, TLayout, TMouse = unknown> = {
   /** Bind on CONTAINER (or ELEMENT if container === element): <view bindtouchstart={handlePointerDown} /> */
   handlePointerDown: (e: TTouch) => void;
   /** Bind on CONTAINER (or ELEMENT if container === element): <view bindtouchmove={handlePointerMove} /> */
@@ -25,6 +25,14 @@ type UsePointerInteractionReturnValueBase<TTouch, TLayout> = {
   handlePointerUp: (e: TTouch) => void;
   /** Bind on ELEMENT: <view bindlayoutchange={handleElementLayoutChange} /> */
   handleElementLayoutChange: (e: TLayout) => void;
+  /** Web compat: <view bindmousedown={handleMouseDown} /> */
+  handleMouseDown: (e: TMouse) => void;
+  /** Web compat: <view bindmousemove={handleMouseMove} /> */
+  handleMouseMove: (e: TMouse) => void;
+  /** Web compat: <view bindmouseup={handleMouseUp} /> */
+  handleMouseUp: (e: TMouse) => void;
+  /** Web compat: <view global-bindmouseup={handleMouseCancel} /> */
+  handleMouseCancel: () => void;
 };
 
 export type {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "exclude": ["dist/"]
+  "exclude": ["dist/", "web/"]
 }

--- a/web/rsbuild.config.ts
+++ b/web/rsbuild.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  root: __dirname,
+  source: {
+    entry: {
+      index: './src/index.tsx',
+    },
+  },
+  output: {
+    distPath: {
+      root: path.join(__dirname, 'dist'),
+    },
+  },
+  server: {
+    publicDir: [
+      {
+        name: path.join(__dirname, '..', 'dist'),
+      },
+    ],
+  },
+  html: {
+    title: 'MTC Color Picker — Lynx for Web',
+    meta: {
+      viewport: 'width=device-width, initial-scale=1.0, viewport-fit=cover',
+    },
+  },
+});

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,0 +1,300 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0c0c0c;
+  color: #e0e0e0;
+  -webkit-font-smoothing: antialiased;
+}
+
+.container {
+  display: flex;
+  height: 100dvh;
+}
+
+/* ---- Desktop sidebar ---- */
+.sidebar {
+  width: 240px;
+  padding: 20px 12px;
+  border-right: 1px solid #1e1e1e;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex-shrink: 0;
+  overflow-y: auto;
+}
+
+.title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  padding: 0 8px;
+  letter-spacing: 0.01em;
+}
+
+.demo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.demo-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: #777;
+  padding: 7px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.demo-btn:hover {
+  background: #1a1a1a;
+  color: #ccc;
+}
+
+.demo-btn.active {
+  background: #162036;
+  color: #5b9cf5;
+  border-color: #1e3a5f;
+}
+
+/* ---- Mobile top bar ---- */
+.topbar {
+  display: none;
+  position: relative;
+  z-index: 100;
+}
+
+.topbar-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 16px;
+  background: #111;
+  border: none;
+  border-bottom: 1px solid #1e1e1e;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  font-family: inherit;
+}
+
+.topbar-label {
+  flex: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.topbar-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  background: #222;
+  color: #888;
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  flex-shrink: 0;
+}
+
+.topbar-trigger.open .topbar-chevron {
+  transform: rotate(180deg);
+}
+
+/* ---- Overlay ---- */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: overlay-in 0.2s ease-out both;
+}
+
+.overlay-exit {
+  animation: overlay-out 0.18s ease-in both;
+}
+
+@keyframes overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes overlay-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+/* ---- Dropdown ---- */
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  animation: dropdown-in 0.22s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+.dropdown-exit {
+  animation: dropdown-out 0.18s cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+@keyframes dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dropdown-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+.dropdown-inner {
+  background: #161616;
+  border-bottom: 1px solid #1e1e1e;
+  padding: 6px;
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.55),
+    0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.dropdown-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 11px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #888;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  font-family: inherit;
+  transition: background 0.12s;
+  animation: item-in 0.2s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+@keyframes item-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.dropdown-item:active {
+  background: #1c1c1c;
+}
+
+.dropdown-item.active {
+  color: #fff;
+  background: #1a1a1a;
+}
+
+.dropdown-item-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.dropdown-tag {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  text-transform: uppercase;
+}
+
+.dropdown-tag--mtc {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+}
+
+.dropdown-tag--btcmts {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.dropdown-tag--btc {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+/* ---- Preview ---- */
+.preview {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+lynx-view {
+  max-width: 420px;
+  max-height: 800px;
+  width: 100%;
+  height: 100%;
+}
+
+/* ---- Mobile ---- */
+@media (max-width: 640px) {
+  .container {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .topbar {
+    display: block;
+  }
+
+  .preview {
+    padding: 0;
+  }
+
+  lynx-view {
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useRef, useEffect } from 'react';
+import './App.css';
+
+const demos = [
+  { name: 'MTC ColorPicker (BTC)', tag: 'MTC', bundle: 'MTCColorPicker-BTC.web.bundle' },
+  { name: 'MTC ColorPicker (Signal)', tag: 'MTC', bundle: 'MTCColorPicker-Signal.web.bundle' },
+  { name: 'MTC ColorPicker (State)', tag: 'MTC', bundle: 'MTCColorPicker-State.web.bundle' },
+  { name: 'BTC-MTS ColorPicker (MTS)', tag: 'BTC-MTS', bundle: 'BTCMTSColorPicker-MTSCoord.web.bundle' },
+  { name: 'BTC-MTS ColorPicker (BTS)', tag: 'BTC-MTS', bundle: 'BTCMTSColorPicker-BTSCoord.web.bundle' },
+  { name: 'BTC-MTS Slider', tag: 'BTC-MTS', bundle: 'BTCMTSSlider.web.bundle' },
+  { name: 'BTC Slider', tag: 'BTC', bundle: 'BTCSlider.web.bundle' },
+];
+
+export function App() {
+  const [selected, setSelected] = useState(demos[0]);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const closeMenu = () => {
+    setClosing(true);
+    setTimeout(() => {
+      setMenuOpen(false);
+      setClosing(false);
+    }, 180);
+  };
+
+  const toggleMenu = () => {
+    if (menuOpen) {
+      closeMenu();
+    } else {
+      setMenuOpen(true);
+    }
+  };
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [menuOpen]);
+
+  return (
+    <div className="container">
+      {/* Desktop sidebar */}
+      <nav className="sidebar">
+        <h1 className="title">MTC Color Picker</h1>
+        <div className="demo-list">
+          {demos.map((demo) => (
+            <button
+              key={demo.bundle}
+              className={`demo-btn ${selected.bundle === demo.bundle ? 'active' : ''}`}
+              onClick={() => setSelected(demo)}
+            >
+              {demo.name}
+            </button>
+          ))}
+        </div>
+      </nav>
+
+      {/* Mobile top bar */}
+      <div className="topbar">
+        <button
+          className={`topbar-trigger ${menuOpen && !closing ? 'open' : ''}`}
+          onClick={toggleMenu}
+        >
+          <span className="topbar-label">{selected.name}</span>
+          <span className="topbar-chevron">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+              <path
+                d="M2.5 3.75L5 6.25L7.5 3.75"
+                stroke="currentColor"
+                strokeWidth="1.25"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+        </button>
+
+        {menuOpen && (
+          <>
+            <div
+              className={`overlay ${closing ? 'overlay-exit' : ''}`}
+              onClick={closeMenu}
+            />
+            <div
+              ref={dropdownRef}
+              className={`dropdown ${closing ? 'dropdown-exit' : ''}`}
+            >
+              <div className="dropdown-inner">
+                {demos.map((demo, i) => (
+                  <button
+                    key={demo.bundle}
+                    className={`dropdown-item ${selected.bundle === demo.bundle ? 'active' : ''}`}
+                    style={{ animationDelay: `${i * 20}ms` }}
+                    onClick={() => {
+                      setSelected(demo);
+                      closeMenu();
+                    }}
+                  >
+                    <span className="dropdown-item-name">{demo.name}</span>
+                    <span className={`dropdown-tag dropdown-tag--${demo.tag.toLowerCase().replace('-', '')}`}>
+                      {demo.tag}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Lynx view */}
+      <main className="preview">
+        <lynx-view
+          key={selected.bundle}
+          style={{ width: '100%', height: '100%' }}
+          url={`/${selected.bundle}`}
+        />
+      </main>
+    </div>
+  );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './App.css';
 
 const demos = [
@@ -16,14 +16,30 @@ export function App() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [closing, setClosing] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<number | null>(null);
 
-  const closeMenu = () => {
+  const closeMenu = useCallback(() => {
+    // Coalesce multiple rapid close calls so we only ever have one timer.
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+    }
     setClosing(true);
-    setTimeout(() => {
+    closeTimerRef.current = window.setTimeout(() => {
       setMenuOpen(false);
       setClosing(false);
+      closeTimerRef.current = null;
     }, 180);
-  };
+  }, []);
+
+  // Clear any pending close timer on unmount to avoid setState-after-unmount.
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const toggleMenu = () => {
     if (menuOpen) {
@@ -40,7 +56,7 @@ export function App() {
     };
     document.addEventListener('keydown', handleEsc);
     return () => document.removeEventListener('keydown', handleEsc);
-  }, [menuOpen]);
+  }, [menuOpen, closeMenu]);
 
   return (
     <div className="container">

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -1,0 +1,8 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    'lynx-view': React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLElement> & { url?: string },
+      HTMLElement
+    >;
+  }
+}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '@lynx-js/web-core/index.css';
+import '@lynx-js/web-elements/index.css';
+import '@lynx-js/web-core';
+import '@lynx-js/web-elements/all';
+import { App } from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Enable Lynx for Web by adding `environments: { web: {}, lynx: {} }` to `lynx.config.ts`, so rspeedy produces `.web.bundle` alongside `.lynx.bundle`
- Add a web host shell (`web/`) using `@lynx-js/web-core` and `@lynx-js/web-elements` to load bundles via `<lynx-view>` in a browser
- New scripts: `pnpm web:dev` (dev server) and `pnpm web:build` (production build)

## Known issues

This PR enables the Web environment and provides a shell to preview demos in a browser, but **does not guarantee the original UIs work correctly on Web**. Specifically:

- **Layout is off** — component positioning/sizing does not match the native Lynx rendering
- **Slider drag broken** — sliders only respond to tap, not drag/swipe gestures

These are likely issues in the Lynx components themselves (pointer event handling, layout engine differences between native and web) that need to be investigated and fixed separately.

## Usage

```bash
# Build Lynx bundles (web + native)
pnpm build

# Start the web host dev server
pnpm web:dev
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new web-based interface featuring a demo selector with sidebar navigation for desktop and an adaptive mobile menu for smaller screens.
  * Integrated a preview pane for interactive viewing of selected demonstrations.
  * Implemented a dark-themed, fully responsive design across all devices.

* **Chores**
  * Set up web application build configuration and development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->